### PR TITLE
fix: add plugin cache guard to prevent stale version installs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "1.9.5",
+  "version": "1.9.6-dev",
   "description": "AI-native capability benchmarking with structured SDLC workflow. Measures interview depth, pushback ratio, prompt quality, and iteration efficiency. Worker subagent per task for context isolation.",
   "author": {
     "name": "NaironAI",

--- a/.github/workflows/post-release-bump.yml
+++ b/.github/workflows/post-release-bump.yml
@@ -1,0 +1,50 @@
+name: Post-Release Version Bump
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute next dev version
+        id: next
+        run: |
+          # Extract version from tag (strip leading 'v')
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${TAG#v}"
+
+          # Bump patch: 1.9.5 -> 1.9.6-dev
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+          NEXT="${MAJOR}.${MINOR}.$((PATCH + 1))-dev"
+          echo "version=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "Bumping to $NEXT"
+
+      - name: Update package.json
+        run: |
+          NEXT="${{ steps.next.outputs.version }}"
+          jq --arg v "$NEXT" '.version = $v' package.json > package.tmp && mv package.tmp package.json
+
+      - name: Update plugin.json
+        run: |
+          NEXT="${{ steps.next.outputs.version }}"
+          jq --arg v "$NEXT" '.version = $v' .claude-plugin/plugin.json > plugin.tmp && mv plugin.tmp .claude-plugin/plugin.json
+
+      - name: Commit and push
+        run: |
+          NEXT="${{ steps.next.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json .claude-plugin/plugin.json
+          git commit -m "chore: bump version to ${NEXT} [skip ci]"
+          git push

--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -1,0 +1,68 @@
+name: Version Guard
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-dev-version:
+    runs-on: ubuntu-latest
+    # Skip the bump commit itself
+    if: "!contains(github.event.head_commit.message, 'chore: bump version to')"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Ensure version has -dev suffix
+        run: |
+          PKG_VERSION=$(jq -r '.version' package.json)
+          PLUGIN_VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
+
+          FAILED=0
+
+          if [[ "$PKG_VERSION" != *-dev ]]; then
+            echo "::error::package.json version '${PKG_VERSION}' is missing -dev suffix on main"
+            FAILED=1
+          fi
+
+          if [[ "$PLUGIN_VERSION" != *-dev ]]; then
+            echo "::error::plugin.json version '${PLUGIN_VERSION}' is missing -dev suffix on main"
+            FAILED=1
+          fi
+
+          if [[ "$FAILED" -eq 1 ]]; then
+            echo ""
+            echo "Versions on main must always end in '-dev' to prevent stale plugin cache hits."
+            echo "The post-release-bump workflow should handle this automatically."
+            echo "If you're seeing this, the post-release bump may have failed."
+            exit 1
+          fi
+
+          echo "Versions OK: package.json=${PKG_VERSION}, plugin.json=${PLUGIN_VERSION}"
+
+      - name: Open issue if guard fails
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'version-guard',
+              state: 'open'
+            });
+            if (existing.data.length > 0) {
+              console.log('Issue already exists, skipping');
+              return;
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Version guard failed: main is missing -dev suffix',
+              body: `The version on \`main\` does not have a \`-dev\` suffix.\n\nThis means the post-release version bump workflow likely failed after the last release. Users installing with \`@latest\` may get a stale cached version.\n\n**Fix:** Manually bump the version in \`package.json\` and \`.claude-plugin/plugin.json\` to the next dev version (e.g. \`1.9.6-dev\`).\n\nTriggered by commit: ${context.sha}`,
+              labels: ['version-guard', 'bug']
+            });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "1.9.5",
+  "version": "1.9.6-dev",
   "description": "AI-native capability benchmarking and structured SDLC workflow for Claude Code",
   "type": "module",
   "private": true,


### PR DESCRIPTION
## What this PR does

Adds two GitHub Actions workflows to prevent Claude Code's plugin cache from serving stale versions.

**Problem:** The plugin resolver caches by package.json version and can resolve `@latest` to commits between releases, causing users to get v1.9.2 when v1.9.5 exists (for e.g.)

**Solution:**
1. **post-release-bump.yml**: Automatically bumps main to next -dev version after each release (e.g., v1.9.5 → 1.9.6-dev)
2. **version-guard.yml**: Enforces that main always has -dev suffix, fails CI and opens an issue if missing
3. Bumped current version to 1.9.6-dev

This ensures main is always ahead of any released tag, preventing cache hits on stale code.

## Conversation History

[Part of broader workflow debugging session]

## Demo Video

N/A - infrastructure change

## Social Post

N/A - infrastructure change

## Checklist

- [x] Infrastructure fix to prevent plugin cache issues
- [x] Dual-layer approach: automatic bump + CI guard
- [x] Tested version comparison logic