### PR TITLE
release: v1.9.6

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "1.9.6-dev",
+  "version": "1.9.6",
   "description": "AI-native capability benchmarking with structured SDLC workflow. Measures interview depth, pushback ratio, prompt quality, and iteration efficiency. Worker subagent per task for context isolation.",
   "author": {
     "name": "NaironAI",

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Flux
 
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/CEQMd6fmXk)
-[![Version](https://img.shields.io/badge/version-v1.9.5-green)](https://github.com/Nairon-AI/flux/releases)
+[![Version](https://img.shields.io/badge/version-v1.9.6-green)](https://github.com/Nairon-AI/flux/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)](https://claude.ai/code)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "1.9.6-dev",
+  "version": "1.9.6",
   "description": "AI-native capability benchmarking and structured SDLC workflow for Claude Code",
   "type": "module",
   "private": true,


### PR DESCRIPTION
## What this PR does

Version bump to 1.9.6 for release. Updates package.json, plugin.json, and README badge.

After merging, tag `v1.9.6` and create the GitHub release. The post-release-bump workflow will automatically set main to `1.9.6-dev`.

### What's in v1.9.6

- Plugin cache guard to prevent stale version installs (post-release bump + version guard CI)
- Clear "what to do next" output after `/flux:setup`
- Remove Cartographer skill (redundant with built-in agentmap)
- Claude Code as first-class platform (remove Factory Droid / Codex platform support)
- Adversarial multi-model review positioning in README