### PR TITLE
fix: remove stale plugin update from upgrade instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,13 +128,15 @@ After that, your agent should prime the repository automatically if needed, then
 
 ### Upgrade Flux (existing users)
 
+To upgrade, run the same install command again — it overwrites the existing version:
+
 ```
 /plugin add https://github.com/Nairon-AI/flux@latest
 ```
 
-Then restart your agent/session and let the agent finish Flux setup.
+Then restart your agent/session. That's it.
 
-> **Note:** Do not use `/plugin update flux@nairon-flux` — it resolves from a stale marketplace cache and may install an older version.
+> **Why not `/plugin update`?** The `/plugin update` command resolves from a marketplace cache that can be stale. Re-running `/plugin add ...@latest` always fetches the latest code directly from GitHub.
 
 ## Uninstall Flux (complete removal)
 


### PR DESCRIPTION
## What this PR does

Removes `/plugin update flux@nairon-flux` from the upgrade instructions. It resolves from a stale marketplace cache and installs older versions (e.g., 1.9.5 instead of 1.9.6).

Only recommends `/plugin add https://github.com/Nairon-AI/flux@latest` which fetches fresh from git. Added a warning note so users don't try the old command.