### PR TITLE
docs: major README restructure with TOC, problem section, and Relay roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Upgrade Flux. Fetch the README at https://github.com/Nairon-AI/flux for upgrade 
 Uninstall Flux. Fetch the README at https://github.com/Nairon-AI/flux for uninstall instructions.
 ```
 
-The agent handles the rest. You only step in when a slash command or restart is needed.
+After setup, just talk to the agent. Flux parses your message intent and routes to the right workflow — scope, work, review, or reflect — based on session state and what's currently in progress. You and the agent always know what's next.
 
 <details>
 <summary><strong>Agent Instructions</strong> — the agent reads this section when it fetches the README</summary>


### PR DESCRIPTION
## Summary

- **Restructured README** from 817 → ~400 lines with a proper Table of Contents
- **Restored "The Problem" section** with sarcastic, relatable bullet points covering all pain points Flux solves (context amnesia, requirements drift, security roulette, echo chamber, etc.)
- **Split Install section** into user-facing 1-line prompts and collapsible agent-specific instructions
- **Collapsed troubleshooting** into expandable `<details>` blocks
- **Condensed feature sections** into concise descriptions
- **Added Relay v2.0 to Roadmap** — fully autonomous orchestration layer inspired by OpenAI Symphony

## Test plan

- [ ] Verify all TOC anchor links resolve correctly
- [ ] Confirm install/upgrade/uninstall prompts are visible and agent instructions are collapsible
- [ ] Check troubleshooting `<details>` blocks expand/collapse properly
- [ ] Verify Relay roadmap section renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)