### PR TITLE
feat: browser automation detection in prime + agent-browser install

### DIFF
--- a/agents/testing-scout.md
+++ b/agents/testing-scout.md
@@ -78,6 +78,18 @@ ls -la playwright.config.* cypress.config.* cypress/ e2e/ 2>/dev/null
 ls -d integration/ tests/integration/ tests/e2e/ 2>/dev/null
 ```
 
+### Browser Automation (for web apps)
+```bash
+# Detect if this is a web app (has frontend framework or HTML output)
+grep -E '"(react|next|vue|nuxt|svelte|angular|astro|remix|gatsby)"' package.json 2>/dev/null
+ls -la index.html public/index.html src/App.* src/app/ app/ pages/ 2>/dev/null
+
+# Check for browser automation tools
+which agent-browser >/dev/null 2>&1 && echo "agent-browser=installed" || echo "agent-browser=missing"
+which playwright >/dev/null 2>&1 && echo "playwright-cli=installed" || echo "playwright-cli=missing"
+grep -E '"(playwright|puppeteer|selenium|stagehand|agent-browser)"' package.json 2>/dev/null
+```
+
 ### CI Test Config
 ```bash
 # GitHub Actions
@@ -107,6 +119,11 @@ ls -la .gitlab-ci.yml .circleci/config.yml Jenkinsfile .travis.yml 2>/dev/null
 - Unit tests: ✅ Found in [location] / ❌ Not found
 - Integration tests: ✅ Found in [location] / ❌ Not found
 - E2E tests: ✅ Found in [location] / ❌ Not found
+
+### Browser Automation (web apps only)
+- Is web app: ✅ Yes ([framework]) / ❌ No (skip this section)
+- Browser automation tool: ✅ [tool] / ❌ Not configured
+- agent-browser CLI: ✅ Installed / ❌ Missing
 
 ### Coverage
 - Coverage tool: ✅ [tool] / ❌ Not configured

--- a/skills/flux-prime/workflow.md
+++ b/skills/flux-prime/workflow.md
@@ -377,7 +377,39 @@ Ask ONE question per category that has recommendations. Skip categories with no 
 }
 ```
 
-**Question 4: Environment (if gaps exist)**
+**Question 4: Browser Automation (if web app detected AND no browser automation tool)**
+
+Only ask this if the testing scout detected a web app (React, Next, Vue, Svelte, etc.) but found no browser automation tool (Playwright, Cypress, Puppeteer, Stagehand, agent-browser).
+
+```json
+{
+  "questions": [{
+    "question": "Your web app has no browser automation tool. This means agents can't visually verify UI changes or run E2E tests. Install one?",
+    "header": "Browser",
+    "multiSelect": true,
+    "options": [
+      {
+        "label": "Install agent-browser (Recommended)",
+        "description": "Browser automation CLI built for coding agents. Enables visual QA and reproducible evidence. Install: npm i -g agent-browser"
+      },
+      {
+        "label": "Skip",
+        "description": "Set up browser automation later"
+      }
+    ]
+  }]
+}
+```
+
+If "Install agent-browser" selected, run in Phase 6:
+
+```bash
+npm i -g agent-browser 2>&1 | tail -5
+# Verify install
+which agent-browser >/dev/null 2>&1 && echo "agent-browser installed successfully" || echo "agent-browser install failed"
+```
+
+**Question 5: Environment (if gaps exist)**
 
 ```json
 {


### PR DESCRIPTION
## Summary

- **Testing scout** now detects if the project is a web app (React, Next, Vue, Svelte, etc.) and checks for browser automation tools (Playwright, Cypress, Puppeteer, Stagehand, agent-browser)
- **Prime remediation** offers to install `agent-browser` CLI (`npm i -g agent-browser`) when a web app has no browser automation configured
- Includes install verification after `npm i -g agent-browser`

## Test plan

- [ ] Run `/flux:prime` on a web app project without browser automation — should detect gap and offer agent-browser
- [ ] Run `/flux:prime` on a web app with Playwright — should not offer agent-browser
- [ ] Run `/flux:prime` on a non-web project (Go API, CLI tool) — should skip browser automation section entirely
- [ ] Verify `npm i -g agent-browser` installs correctly when selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)