### PR TITLE
feat: add FFF (Fast File Finder) MCP to flux-setup

### DIFF
--- a/scripts/detect-installed.sh
+++ b/scripts/detect-installed.sh
@@ -64,6 +64,9 @@ detect_cli_tools() {
     # Task tracking
     cmd_exists bd && tools+=("beads")
 
+    # File search
+    cmd_exists fff-mcp && tools+=("fff-mcp")
+
     # Agent workflow automation
     cmd_exists agent-browser && tools+=("agent-browser")
     if cmd_exists continues || cmd_exists cont; then

--- a/skills/flux-setup/templates/claude-md-snippet.md
+++ b/skills/flux-setup/templates/claude-md-snippet.md
@@ -65,6 +65,7 @@ This project uses Flux for structured AI development. Use `.flux/bin/fluxctl` in
 - If the user asks "where are we?" or seems unsure what comes next, run `.flux/bin/fluxctl scope-status`
 - If `.flux/context/agentmap.yaml` exists, use it as a fast structural overview of the repo before broad file exploration
 - Treat the agentmap as navigation aid only. Still read the actual files before making changes
+- If the `fff` MCP is available, prefer its tools for file search operations instead of default Glob/find — it's faster, supports fuzzy matching, and ranks by access frecency
 
 **Troubleshooting:**
 - If Flux commands fail or return "Unknown skill", consult the official README: https://github.com/Nairon-AI/flux#troubleshooting

--- a/skills/flux-setup/workflow.md
+++ b/skills/flux-setup/workflow.md
@@ -106,6 +106,7 @@ Use direct config updates to the project-level `.mcp.json` (preferred), then tel
 
 | ID | Name | Category | Benefit | Free | Install Method |
 |----|------|----------|---------|------|----------------|
+| `fff` | FFF | search | **10x faster file search** — fuzzy matching, frecency-aware, git-status-aware file finder replacing default Glob/find | Yes | Binary install + add `mcpServers.fff` to `.mcp.json` |
 | `context7` | Context7 | search | **No more hallucinated APIs** — up-to-date, version-specific library docs in every prompt | Yes | Add `mcpServers.context7` to `.mcp.json` |
 | `exa` | Exa | search | **Fastest AI web search** — real-time research without leaving your session | Yes | Add `mcpServers.exa` to `.mcp.json` |
 | `github` | GitHub | dev | **PRs, issues, actions in Claude** — no context switching to browser | Yes | Add `mcpServers.github` to `.mcp.json` |
@@ -136,11 +137,15 @@ MCP_LIST=$(
 )
 
 # Check each recommended MCP
+HAVE_FFF=$(echo "$MCP_LIST" | grep -qx "fff" && echo 1 || echo 0)
 HAVE_CONTEXT7=$(echo "$MCP_LIST" | grep -qx "context7" && echo 1 || echo 0)
 HAVE_EXA=$(echo "$MCP_LIST" | grep -qx "exa" && echo 1 || echo 0)
 HAVE_GITHUB=$(echo "$MCP_LIST" | grep -qx "github" && echo 1 || echo 0)
 HAVE_SUPERMEMORY=$(echo "$MCP_LIST" | grep -qx "supermemory" && echo 1 || echo 0)
 HAVE_FIRECRAWL=$(echo "$MCP_LIST" | grep -qx "firecrawl" && echo 1 || echo 0)
+
+# FFF binary check (installed separately from MCP config)
+HAVE_FFF_BINARY=$(command -v fff-mcp >/dev/null 2>&1 && echo 1 || echo 0)
 
 # Detect conflicting/similar tools
 HAVE_PERPLEXITY=$(echo "$MCP_LIST" | grep -qx "perplexity" && echo 1 || echo 0)
@@ -199,6 +204,7 @@ Build the question dynamically. For items with conflicts, explain the situation:
 
 For **available** MCPs (no conflict):
 ```json
+{"label": "FFF", "description": "10x faster file search — fuzzy, frecency-aware, git-status-aware (free, installs binary)"}
 {"label": "Context7", "description": "No more hallucinated APIs — up-to-date library docs (free)"}
 {"label": "Exa", "description": "Fastest AI web search — real-time research (free)"}
 {"label": "GitHub", "description": "PRs, issues, actions without leaving Claude (free)"}
@@ -271,6 +277,31 @@ jq '.mcpServers = (.mcpServers // {}) | del(.mcpServers.perplexity) | .mcpServer
 ### Install selected servers
 
 For each selected server (that passed conflict resolution), install it:
+
+**FFF (Fast File Finder):**
+
+FFF requires a binary install before adding the MCP config. It replaces default file search with faster, fuzzy, frecency-aware search.
+
+```bash
+# Step 1: Install the fff-mcp binary (if not already installed)
+if ! command -v fff-mcp >/dev/null 2>&1; then
+  curl -fsSL https://raw.githubusercontent.com/dmtrKovalenko/fff.nvim/main/install-mcp.sh | bash
+fi
+
+# Step 2: Add MCP config (uses stdio, not HTTP)
+tmp=$(mktemp)
+jq '.mcpServers = (.mcpServers // {}) | .mcpServers.fff = {"type":"stdio","command":"fff-mcp","args":[]}' "$MCP_FILE" > "$tmp" && mv "$tmp" "$MCP_FILE"
+```
+
+If the binary install fails (e.g., no curl, unsupported platform), print manual fallback:
+```
+FFF binary installation failed. Install manually:
+  curl -fsSL https://raw.githubusercontent.com/dmtrKovalenko/fff.nvim/main/install-mcp.sh | bash
+
+Or download prebuilt binary from: https://github.com/dmtrKovalenko/fff.nvim/releases
+
+Then re-run /flux:setup to add the MCP config.
+```
 
 **Context7:**
 ```bash
@@ -393,6 +424,7 @@ If settings are not writable or `jq` is missing, print manual instructions:
 MCP servers (install manually in Claude Code):
   1. Run /mcp in chat
   2. Add these servers:
+     - fff: Install binary first (curl -fsSL https://raw.githubusercontent.com/dmtrKovalenko/fff.nvim/main/install-mcp.sh | bash), then add MCP with command "fff-mcp"
      - context7: https://mcp.context7.com/mcp
      - exa: https://mcp.exa.ai/mcp
      - supermemory: https://mcp.supermemory.ai/mcp


### PR DESCRIPTION
## Summary
- Adds [FFF](https://github.com/dmtrKovalenko/fff.nvim) (Fast File Finder) as a recommended MCP server in `/flux:setup`
- FFF is a Rust-based file search tool that's ~10x faster than default Glob/find, with fuzzy matching, frecency-aware sorting, and git status awareness
- Installs as a prebuilt binary via the upstream installer script, then connects as a stdio MCP server

## Changes
- **`workflow.md`**: Added `fff` to recommended MCPs table, conflict detection (`HAVE_FFF`, `HAVE_FFF_BINARY`), installation logic (binary + MCP config), and manual fallback instructions
- **`detect-installed.sh`**: Added `fff-mcp` binary detection in CLI tools section
- **`claude-md-snippet.md`**: Added guidance to prefer fff MCP tools for file search when available

## How it works
Unlike other MCPs (which use HTTP or npx), FFF requires a two-step install:
1. Install the `fff-mcp` binary via `curl -fsSL .../install-mcp.sh | bash` (installs to `~/.local/bin/`)
2. Add stdio MCP config: `{"type":"stdio","command":"fff-mcp","args":[]}`

## Test plan
- [ ] Run `/flux:setup` and verify FFF appears in the MCP recommendation list
- [ ] Select FFF and verify binary installation + MCP config in `.mcp.json`
- [ ] Verify `detect-installed.sh` reports `fff-mcp` when binary is present
- [ ] Verify CLAUDE.md snippet includes fff preference guidance after setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)