### PR TITLE
refactor: remove Supermemory MCP from recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ The `/plugin update` command resolves from a stale marketplace cache. **Do not u
 | [Context7](https://context7.com) | Up-to-date, version-specific library docs — no more hallucinated APIs |
 | [Exa](https://exa.ai) | Fastest AI web search — real-time research without leaving your session |
 | [GitHub](https://github.com/modelcontextprotocol/servers/tree/main/src/github) | PRs, issues, actions in Claude — no context switching to browser |
-| [Supermemory](https://supermemory.ai) | Persistent memory across sessions — never re-explain context |
 | [Firecrawl](https://firecrawl.dev) | Scrape websites and PDFs into clean markdown for agents |
 
 **CLI Tools** — terminal essentials:

--- a/scripts/match-recommendations.py
+++ b/scripts/match-recommendations.py
@@ -427,12 +427,8 @@ def detect_sdlc_gaps(context: dict, user_context: str = "") -> dict:
 
         # --- Memory/Context Friction ---
         # "I already told you", "remember when", re-explaining
-        if (
-            friction.get("context_forgotten", 0) > 0
-            or friction.get("re_explaining", 0) > 0
-        ):
-            if "supermemory" not in installed_mcps:
-                gaps["documentation"].append("no_memory")
+        # Note: Flux brain vault handles persistent memory natively.
+        # No external memory MCP needed.
 
         # --- AGENTS.md Friction ---
         # "that's not how we do it", "wrong directory", model doesn't know project
@@ -623,10 +619,6 @@ def recommendation_fills_gap(rec: dict, gaps: dict) -> tuple[bool, str, str]:
                 "needs_reasoning_model",
                 "Use extended thinking for complex problems",
             ),
-        ],
-        "supermemory": [
-            ("documentation", "no_memory", "Persistent memory"),
-            ("documentation", "frequent_lookups", "Remember what you learned"),
         ],
         "context-management": [("documentation", "no_memory", "Session continuity")],
     }

--- a/scripts/parse-sessions.py
+++ b/scripts/parse-sessions.py
@@ -122,7 +122,7 @@ FRICTION_PATTERNS = [
     (r"how do (other|people|teams)", "search_needed"),
     (r"what's the best (way|practice|approach)", "search_needed"),
     (r"any (alternatives|options) for", "search_needed"),
-    # Memory/Context friction -> supermemory
+    # Memory/Context friction (handled by brain vault)
     (r"I (already|just) told you", "context_forgotten"),
     (r"remember (when|that|earlier)", "context_forgotten"),
     (r"as I (said|mentioned)", "re_explaining"),

--- a/scripts/test_discover_community.py
+++ b/scripts/test_discover_community.py
@@ -36,13 +36,13 @@ def test_build_queries_with_user_context_keywords():
 
 
 def test_extract_tool_candidates_from_text_and_url():
-    text = "Try @context7 and install supermemory for this workflow"
-    url = "https://github.com/supermemoryai/supermemory"
+    text = "Try @context7 and install firecrawl for this workflow"
+    url = "https://github.com/mendableai/firecrawl"
     tools = discover_community.extract_tool_candidates(text, url)
 
     lowered = [t.lower() for t in tools]
     assert "context7" in lowered
-    assert "supermemory" in lowered
+    assert "firecrawl" in lowered
 
 
 def test_discovery_score_prefers_retweets_and_likes():

--- a/scripts/test_e2e.py
+++ b/scripts/test_e2e.py
@@ -551,8 +551,8 @@ def test_user_context_integration():
 
     print(f"Recommendations: {all_recs}")
 
-    # Should recommend frontend-models for CSS and supermemory for forgetting
-    expected = ["frontend-models", "supermemory"]
+    # Should recommend frontend-models for CSS friction
+    expected = ["frontend-models"]
     found = [r for r in expected if r in all_recs]
 
     if len(found) >= 1:  # At least one expected recommendation

--- a/scripts/test_friction_coverage.py
+++ b/scripts/test_friction_coverage.py
@@ -74,7 +74,7 @@ FRICTION_SCENARIOS = [
                 "tool_errors": {"total": 0},
             },
         },
-        "expected_tools": ["context7", "supermemory"],
+        "expected_tools": ["context7"],
         "expected_phase": "implementation",
     },
     # -------------------------------------------------------------------------
@@ -85,15 +85,6 @@ FRICTION_SCENARIOS = [
         "context": make_context({"search_needed": 3}),
         "expected_tools": ["exa"],
         "expected_phase": "requirements",
-    },
-    # -------------------------------------------------------------------------
-    # MEMORY & CONTEXT ISSUES
-    # -------------------------------------------------------------------------
-    {
-        "name": "Model forgets project context",
-        "context": make_context({"context_forgotten": 2, "re_explaining": 3}),
-        "expected_tools": ["supermemory"],
-        "expected_phase": "documentation",
     },
     {
         "name": "No AGENTS.md - model doesn't know project conventions",

--- a/scripts/test_match_recommendations.py
+++ b/scripts/test_match_recommendations.py
@@ -194,20 +194,6 @@ class TestGapDetection:
         gaps = detect_sdlc_gaps(context)
         assert "no_agents_md" not in gaps["documentation"]
 
-    def test_supermemory_fills_memory_gap(self):
-        """Supermemory MCP fills memory gap."""
-        context = {
-            "installed": {
-                "mcps": ["supermemory"],
-                "plugins": [],
-                "cli_tools": [],
-                "applications": [],
-            },
-            "repo": {},
-        }
-        gaps = detect_sdlc_gaps(context)
-        assert "no_memory" not in gaps["documentation"]
-
     def test_context7_fills_doc_lookup_gap(self):
         """Context7 MCP fills doc lookup gap."""
         context = {
@@ -411,14 +397,6 @@ class TestRecommendationMatching:
         assert fills is True
         assert phase == "requirements"
 
-    def test_supermemory_matches_no_memory_gap(self):
-        """Supermemory should match when no memory tool detected."""
-        rec = {"name": "supermemory", "sdlc_phase": "documentation"}
-        gaps = {"documentation": ["no_memory"]}
-        fills, phase, reason = recommendation_fills_gap(rec, gaps)
-        assert fills is True
-        assert phase == "documentation"
-
     def test_context7_matches_no_doc_lookup_gap(self):
         """Context7 should match when no doc lookup detected."""
         rec = {"name": "context7", "sdlc_phase": "implementation"}
@@ -506,7 +484,6 @@ class TestFullMatchingPipeline:
                     "context7",
                     "linear",
                     "github",
-                    "supermemory",
                     "figma",
                     "excalidraw",
                 ],
@@ -543,7 +520,7 @@ class TestFullMatchingPipeline:
             },
             "repo": {},
             "preferences": {
-                "dismissed": ["exa", "lefthook", "supermemory"],
+                "dismissed": ["exa", "lefthook"],
                 "alternatives": {},
             },
         }
@@ -556,7 +533,6 @@ class TestFullMatchingPipeline:
 
         assert "exa" not in recommended_names
         assert "lefthook" not in recommended_names
-        assert "supermemory" not in recommended_names
 
         # Should be in skipped list
         skipped_names = [s["name"] for s in results["skipped"]]

--- a/skills/flux-setup/SKILL.md
+++ b/skills/flux-setup/SKILL.md
@@ -18,7 +18,6 @@ Install fluxctl locally and add instructions to project docs. **Fully optional**
   - **Context7** — no more hallucinated APIs, up-to-date library docs in every prompt
   - **Exa** — fastest AI web search, real-time research without leaving your session
   - **GitHub** — PRs, issues, actions directly in Claude, no context switching
-  - **Supermemory** — never re-explain context, persistent memory across sessions
 - **Optional** additional MCP:
   - **Firecrawl** — scrape websites and parse PDFs into LLM-ready markdown
 - **Optional** recommended CLI tools:

--- a/skills/flux-setup/workflow.md
+++ b/skills/flux-setup/workflow.md
@@ -110,7 +110,6 @@ Use direct config updates to the project-level `.mcp.json` (preferred), then tel
 | `context7` | Context7 | search | **No more hallucinated APIs** — up-to-date, version-specific library docs in every prompt | Yes | Add `mcpServers.context7` to `.mcp.json` |
 | `exa` | Exa | search | **Fastest AI web search** — real-time research without leaving your session | Yes | Add `mcpServers.exa` to `.mcp.json` |
 | `github` | GitHub | dev | **PRs, issues, actions in Claude** — no context switching to browser | Yes | Add `mcpServers.github` to `.mcp.json` |
-| `supermemory` | Supermemory | memory | **Never re-explain context** — persistent memory across all sessions | Yes | Add `mcpServers.supermemory` to `.mcp.json` |
 | `firecrawl` | Firecrawl | search | **Clean markdown + PDF parsing for agents** — crawl and scrape hard websites | Freemium | Add `mcpServers.firecrawl` to `.mcp.json` |
 
 ### Conflict Detection
@@ -141,7 +140,6 @@ HAVE_FFF=$(echo "$MCP_LIST" | grep -qx "fff" && echo 1 || echo 0)
 HAVE_CONTEXT7=$(echo "$MCP_LIST" | grep -qx "context7" && echo 1 || echo 0)
 HAVE_EXA=$(echo "$MCP_LIST" | grep -qx "exa" && echo 1 || echo 0)
 HAVE_GITHUB=$(echo "$MCP_LIST" | grep -qx "github" && echo 1 || echo 0)
-HAVE_SUPERMEMORY=$(echo "$MCP_LIST" | grep -qx "supermemory" && echo 1 || echo 0)
 HAVE_FIRECRAWL=$(echo "$MCP_LIST" | grep -qx "firecrawl" && echo 1 || echo 0)
 
 # FFF binary check (installed separately from MCP config)
@@ -152,10 +150,6 @@ HAVE_PERPLEXITY=$(echo "$MCP_LIST" | grep -qx "perplexity" && echo 1 || echo 0)
 HAVE_TAVILY=$(echo "$MCP_LIST" | grep -qx "tavily" && echo 1 || echo 0)
 HAVE_BRAVE=$(echo "$MCP_LIST" | grep -qx "brave" && echo 1 || echo 0)
 HAVE_SERPER=$(echo "$MCP_LIST" | grep -qx "serper" && echo 1 || echo 0)
-
-# Memory category conflicts
-HAVE_MEM0=$(echo "$MCP_LIST" | grep -qx "mem0" && echo 1 || echo 0)
-HAVE_LANGMEM=$(echo "$MCP_LIST" | grep -Eiq "^langmem$|langchain.*memory" && echo 1 || echo 0)
 
 # Docs category conflicts
 HAVE_DEVDOCS=$(echo "$MCP_LIST" | grep -qx "devdocs" && echo 1 || echo 0)
@@ -208,7 +202,6 @@ For **available** MCPs (no conflict):
 {"label": "Context7", "description": "No more hallucinated APIs — up-to-date library docs (free)"}
 {"label": "Exa", "description": "Fastest AI web search — real-time research (free)"}
 {"label": "GitHub", "description": "PRs, issues, actions without leaving Claude (free)"}
-{"label": "Supermemory", "description": "Never re-explain context — persistent memory (free)"}
 {"label": "Firecrawl", "description": "Scrape websites/PDFs into clean markdown for agents (freemium)"}
 ```
 
@@ -223,20 +216,6 @@ For MCPs with **conflicts**, use a separate question per conflict:
     {"label": "Keep Perplexity", "description": "Don't install Exa, keep your current setup"},
     {"label": "Switch to Exa", "description": "Remove Perplexity, install Exa (recommended for speed)"},
     {"label": "Keep both", "description": "Install Exa alongside Perplexity (may cause duplicate results)"},
-    {"label": "Skip", "description": "Decide later"}
-  ]
-}
-```
-
-**Example: Supermemory conflicts with mem0:**
-```json
-{
-  "header": "Memory MCP Conflict",
-  "question": "You have mem0 installed. Supermemory offers cross-app sync and knowledge graphs. How to proceed?",
-  "options": [
-    {"label": "Keep mem0", "description": "Don't install Supermemory"},
-    {"label": "Switch to Supermemory", "description": "Remove mem0, install Supermemory"},
-    {"label": "Keep both", "description": "Use both memory systems (may duplicate memories)"},
     {"label": "Skip", "description": "Decide later"}
   ]
 }
@@ -322,12 +301,6 @@ tmp=$(mktemp)
 jq '.mcpServers = (.mcpServers // {}) | .mcpServers.github = {"command":"npx","args":["-y","@modelcontextprotocol/server-github"]}' "$MCP_FILE" > "$tmp" && mv "$tmp" "$MCP_FILE"
 ```
 
-**Supermemory:**
-```bash
-tmp=$(mktemp)
-jq '.mcpServers = (.mcpServers // {}) | .mcpServers.supermemory = {"type":"http","url":"https://mcp.supermemory.ai/mcp"}' "$MCP_FILE" > "$tmp" && mv "$tmp" "$MCP_FILE"
-```
-
 **Firecrawl:**
 ```bash
 tmp=$(mktemp)
@@ -365,7 +338,7 @@ tmp=$(mktemp)
 jq --arg token "<user_provided_token>" '.mcpServers = (.mcpServers // {}) | .mcpServers.github = {"command":"npx","args":["-y","@modelcontextprotocol/server-github"],"env":{"GITHUB_PERSONAL_ACCESS_TOKEN":$token}}' "$MCP_FILE" > "$tmp" && mv "$tmp" "$MCP_FILE"
 ```
 
-**Context7 / Exa / Supermemory / Firecrawl API keys:**
+**Context7 / Exa / Firecrawl API keys:**
 
 These work without keys but keys unlock higher rate limits. Only ask if user installed them:
 
@@ -378,7 +351,6 @@ These work without keys but keys unlock higher rate limits. Only ask if user ins
     // Only show options for MCPs that were just installed
     {"label": "Context7 key", "description": "Higher rate limits (free key from context7.com/dashboard)"},
     {"label": "Exa key", "description": "Higher rate limits (free key from exa.ai)"},
-    {"label": "Supermemory key", "description": "Higher rate limits (free key from supermemory.ai)"},
     {"label": "Firecrawl key", "description": "Required for higher quotas (free tier at firecrawl.dev)"},
     {"label": "Skip", "description": "Use free tier for all (can add keys later)"}
   ]
@@ -402,7 +374,6 @@ set_mcp_env_key() {
 
 # Call based on user selections:
 # set_mcp_env_key "exa" "EXA_API_KEY" "<user_provided_exa_key>"
-# set_mcp_env_key "supermemory" "SUPERMEMORY_API_KEY" "<user_provided_supermemory_key>"
 # set_mcp_env_key "firecrawl" "FIRECRAWL_API_KEY" "<user_provided_firecrawl_key>"
 # Context7 key support may vary by provider release; skip if no documented env var.
 ```
@@ -427,7 +398,6 @@ MCP servers (install manually in Claude Code):
      - fff: Install binary first (curl -fsSL https://raw.githubusercontent.com/dmtrKovalenko/fff.nvim/main/install-mcp.sh | bash), then add MCP with command "fff-mcp"
      - context7: https://mcp.context7.com/mcp
      - exa: https://mcp.exa.ai/mcp
-     - supermemory: https://mcp.supermemory.ai/mcp
      - firecrawl: npx -y firecrawl-mcp
      - github: npx -y @modelcontextprotocol/server-github
   3. Restart Claude Code with `--resume` to pick up where you left off
@@ -966,7 +936,7 @@ Read current `.flux/meta.json`, add/update these fields (preserve all others):
   "setup_version": "<PLUGIN_VERSION>",
   "setup_date": "<ISO_DATE>",
   "installed_by_flux": {
-    "mcp_servers": ["<list of MCP server names installed this session, e.g. context7, exa, github, supermemory, firecrawl>"],
+    "mcp_servers": ["<list of MCP server names installed this session, e.g. fff, context7, exa, github, firecrawl>"],
     "skills": ["<list of skill names installed this session, e.g. ui-skills, taste-skill, agent-skills-vercel>"],
     "desktop_apps": ["<list of desktop apps installed this session, e.g. raycast, superset, wispr-flow, granola>"],
     "cli_tools": ["<list of CLI tools installed this session, e.g. gh, jq, fzf, lefthook, agent-browser, cli-continues>"]
@@ -1498,10 +1468,10 @@ Installed:
 
 ```
 MCP servers:
+- FFF: <installed | already installed | skipped>
 - Context7: <installed | installed + key | already installed | skipped>
 - Exa: <installed | installed + key | already installed | skipped>
 - GitHub: <installed | installed + token | already installed | skipped>
-- Supermemory: <installed | installed + key | already installed | skipped>
 - Firecrawl: <installed | installed + key | already installed | skipped>
 ```
 
@@ -1516,7 +1486,6 @@ Use tracking variables from Step 4c to determine status:
 ```
 Conflicts resolved:
 - Switched from Perplexity to Exa (faster, AI-optimized)
-- Kept mem0 alongside Supermemory
 ```
 
 If all were skipped, show:


### PR DESCRIPTION
## Summary
- Removes Supermemory from all Flux recommendations — setup, README, recommendation engine, gap detection, and tests
- Supermemory overlaps with Flux's native brain vault (`brain/pitfalls/`, `brain/principles.md`), `.flux/` session state, and `fluxctl session-state` resumption
- No external memory MCP needed — Flux already handles persistent project memory across sessions

## Files changed
- **README.md**: Remove from "What Flux offers to install" table
- **SKILL.md**: Remove from setup description
- **workflow.md**: Remove from MCP table, conflict detection, option templates, install logic, API key section, manual fallback, and summary
- **match-recommendations.py**: Remove memory gap detection and supermemory gap mapping
- **parse-sessions.py**: Update comment (memory friction handled by brain vault)
- **test_*.py**: Remove supermemory-related test cases and fixtures

## Test plan
- [ ] Run `python -m pytest scripts/test_match_recommendations.py` — all tests pass
- [ ] Run `python -m pytest scripts/test_friction_coverage.py` — all tests pass
- [ ] Verify no remaining supermemory references outside CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)