### PR TITLE
refactor: remove Claudeception, port skill extraction into reflect

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,11 +174,6 @@ The `/plugin update` command resolves from a stale marketplace cache. **Do not u
 | [Wispr Flow](https://wisprflow.com) | Voice-to-text dictation — 4x faster than typing |
 | [Granola](https://granola.ai) | AI meeting notes without a bot joining your calls |
 
-**Agent Skills**:
-
-| Skill | Why |
-|-------|-----|
-| [Claudeception](https://github.com/blader/Claudeception) | Continuous learning — extracts reusable knowledge from work sessions |
 
 </details>
 

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -69,7 +69,7 @@ Use `--deep` for high-stakes or ambiguous features.
 <p><em>Coming soon</em></p>
 </details>
 
-Initializes Flux in your project. Creates `.flux/` directory structure and bootstraps claudeception skill.
+Initializes Flux in your project. Creates `.flux/` directory structure, configures preferences, and optionally installs productivity tools (MCP servers, CLI tools, desktop apps).
 
 ### /flux:plan
 

--- a/scripts/match-recommendations.py
+++ b/scripts/match-recommendations.py
@@ -602,9 +602,6 @@ def recommendation_fills_gap(rec: dict, gaps: dict) -> tuple[bool, str, str]:
         "agents-md-structure": [
             ("documentation", "no_agents_md", "AI knows your project")
         ],
-        "claudeception": [
-            ("documentation", "no_memory", "Extract and retain session learnings")
-        ],
         # Model recommendations
         "frontend-models": [
             (

--- a/skills/flux-reflect/SKILL.md
+++ b/skills/flux-reflect/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: flux-reflect
 description: >-
-  Reflect on the conversation and update the brain vault. Use when wrapping up, after mistakes
-  or corrections, or when significant codebase knowledge was gained. Triggers: /flux:reflect,
-  "reflect", "remember this".
+  Reflect on the conversation and persist learnings — brain vault notes, skill extraction,
+  or structural enforcement. Use when wrapping up, after mistakes or corrections, after
+  non-obvious debugging, or when significant codebase knowledge was gained.
+  Triggers: /flux:reflect, "reflect", "remember this", "save this as a skill".
 user-invocable: false
 ---
 
 # Reflect
 
-Review the conversation and persist learnings — to `brain/`, to skill files, or as structural enforcement.
+Review the conversation and persist learnings — to `brain/`, as new skills, to existing skill files, or as structural enforcement.
 
-Adapted from [brainmaxxing](https://github.com/poteto/brainmaxxing) by [@poteto](https://github.com/poteto).
+Adapted from [brainmaxxing](https://github.com/poteto/brainmaxxing) by [@poteto](https://github.com/poteto), with skill extraction adapted from [Claudeception](https://github.com/blader/Claudeception).
 
 ## Process
 
@@ -24,7 +25,10 @@ Adapted from [brainmaxxing](https://github.com/poteto/brainmaxxing) by [@poteto]
    - Decisions made and their rationale
    - Friction in skill execution, orchestration, or delegation
    - Repeated manual steps that could be automated or encoded
-3. **Skip** anything trivial or already captured in existing brain files
+   - Non-obvious debugging solutions (>10 min investigation, not in docs)
+   - Error resolutions where the error message was misleading
+   - Workarounds discovered through trial-and-error
+3. **Skip** anything trivial or already captured in existing brain files or skills
 4. **Route each learning** to the right destination (see Routing below)
 5. **Update `brain/index.md`** if any brain files were added or removed
 
@@ -32,9 +36,15 @@ Adapted from [brainmaxxing](https://github.com/poteto/brainmaxxing) by [@poteto]
 
 Not everything belongs in the brain. Route each learning to where it will have the most impact.
 
-### Structural enforcement check
+### Decision flow
 
-Before routing a learning to `brain/`, ask: can this be a lint rule, script, metadata flag, or runtime check? If yes, encode it structurally and skip the brain note. See `brain/principles/encode-lessons-in-structure.md`.
+For each learning, ask in order:
+
+1. **Can this be a lint rule, script, metadata flag, or runtime check?** → Encode it structurally. See `brain/principles/encode-lessons-in-structure.md`.
+2. **Is this a reusable, non-obvious solution with clear trigger conditions?** → Extract as a new skill (see Skill Extraction below).
+3. **Is this about how an existing skill works?** → Update that skill directly.
+4. **Is this codebase knowledge, a principle, or a gotcha?** → Write to `brain/`.
+5. **Is this follow-up work?** → File as a backlog item via `fluxctl`.
 
 ### Brain files (`brain/`)
 
@@ -44,9 +54,68 @@ Codebase knowledge, principles, gotchas — anything that informs future session
 - Group in directories with index files using `[[wikilinks]]`.
 - No inlined content in index files.
 
+### Skill extraction (`.claude/skills/`)
+
+When a learning meets ALL of these criteria, extract it as a standalone skill:
+
+**Criteria:**
+- **Reusable** — will help with future tasks, not just this instance
+- **Non-trivial** — requires discovery, not just documentation lookup
+- **Specific** — has clear trigger conditions (error messages, symptoms, scenarios)
+- **Verified** — the solution actually worked in this session
+
+**When to extract:**
+- Non-obvious debugging that took significant investigation
+- Error resolution where the root cause wasn't what the error message suggested
+- Workaround for a tool/framework limitation found through experimentation
+- Tool integration knowledge that documentation doesn't cover well
+
+**Process:**
+
+1. **Check for existing skills** — search `.claude/skills/` and `~/.claude/skills/` for related skills before creating a new one. Update existing skills if the trigger overlaps.
+
+2. **Create the skill file** at `.claude/skills/[skill-name]/SKILL.md`:
+
+```markdown
+---
+name: [descriptive-kebab-case-name]
+description: |
+  [Precise description including: (1) exact use cases, (2) trigger conditions
+  like specific error messages or symptoms, (3) what problem this solves.
+  Be specific enough that semantic matching surfaces this skill when relevant.]
+version: 1.0.0
+date: [YYYY-MM-DD]
+---
+
+# [Skill Name]
+
+## Problem
+[What this skill addresses]
+
+## Trigger Conditions
+[When to use — exact error messages, symptoms, scenarios]
+
+## Solution
+[Step-by-step solution]
+
+## Verification
+[How to confirm it worked]
+
+## Notes
+[Caveats, edge cases, related considerations]
+```
+
+3. **Description quality matters** — the description field drives Claude's semantic matching. Include specific error messages, framework names, and action phrases ("Use when...", "Fixes...").
+
+**Don't extract when:**
+- The solution is a standard documentation lookup
+- It's project-specific knowledge (use brain vault instead)
+- It duplicates existing documentation
+- The solution hasn't been verified
+
 ### Skill improvements (`skills/<skill>/`)
 
-If a learning is about how a specific skill works — its process, prompts, or edge cases — update the skill directly.
+If a learning is about how a specific Flux skill works — its process, prompts, or edge cases — update the skill directly.
 
 ### Backlog items
 
@@ -57,7 +126,8 @@ Follow-up work that can't be done during reflection — bugs, non-trivial rewrit
 ```
 ## Reflect Summary
 - Brain: [files created/updated, one-line each]
-- Skills: [skill files modified, one-line each]
+- Skills extracted: [new skill files created, one-line each]
+- Skills updated: [existing skill files modified, one-line each]
 - Structural: [rules/scripts/checks added]
 - Todos: [follow-up items filed]
 ```

--- a/skills/flux-setup/SKILL.md
+++ b/skills/flux-setup/SKILL.md
@@ -13,7 +13,6 @@ Install fluxctl locally and add instructions to project docs. **Fully optional**
 - `fluxctl` accessible from command line (add `.flux/bin` to PATH)
 - Other AI agents (Codex, Cursor, etc.) can read instructions from CLAUDE.md/AGENTS.md
 - Works without Claude Code plugin installed
-- Installs `claudeception` by default (if missing) for continuous learning
 - **Optional** recommended MCP servers (user chooses which to install, all free):
   - **Context7** — no more hallucinated APIs, up-to-date library docs in every prompt
   - **Exa** — fastest AI web search, real-time research without leaving your session

--- a/skills/flux-setup/workflow.md
+++ b/skills/flux-setup/workflow.md
@@ -63,25 +63,7 @@ chmod +x .flux/bin/fluxctl
 
 Then read [templates/usage.md](templates/usage.md) and write it to `.flux/usage.md`.
 
-## Step 4b: Install default skill (Claudeception)
-
-Install Claudeception at project level if not already present:
-
-```bash
-mkdir -p ".claude/skills"
-
-if [ ! -d ".claude/skills/claudeception" ]; then
-  git clone --depth 1 https://github.com/blader/Claudeception.git ".claude/skills/claudeception" 2>/dev/null || true
-fi
-```
-
-If clone fails, continue setup and print this manual fallback command:
-
-```bash
-git clone https://github.com/blader/Claudeception.git .claude/skills/claudeception
-```
-
-## Step 4c: Install recommended MCP servers (Optional)
+## Step 4b: Install recommended MCP servers (Optional)
 
 Flux recommends MCP servers that enhance your AI development workflow. Installation is **optional** — users can skip or select which ones to install.
 
@@ -403,7 +385,7 @@ MCP servers (install manually in Claude Code):
   3. Restart Claude Code with `--resume` to pick up where you left off
 ```
 
-## Step 4d: Install recommended desktop applications (Optional)
+## Step 4c: Install recommended desktop applications (Optional)
 
 Flux recommends productivity applications that enhance AI-augmented development. Installation is **optional** — users can skip or select which ones to install.
 
@@ -583,11 +565,11 @@ Store for summary:
 - `SKIPPED_APPS` — list of apps user chose to skip
 - `CONFLICTS_APPS` — list of app conflicts and resolutions
 
-## Step 4e: Install recommended CLI tools (Optional)
+## Step 4d: Install recommended CLI tools (Optional)
 
 Flux recommends CLI tools that complement the AI development workflow.
 
-**Note:** This step uses `OS_TYPE` detected in Step 4d. CLI tools work on all platforms.
+**Note:** This step uses `OS_TYPE` detected in Step 4c. CLI tools work on all platforms.
 
 ### Available CLI Tools
 
@@ -790,7 +772,7 @@ Store for summary:
 - `INSTALLED_CLI` — list of CLI tools installed this session
 - `SKIPPED_CLI` — list of CLI tools user chose to skip
 
-## Step 4f: Install optional agent skills (Optional)
+## Step 4e: Install optional agent skills (Optional)
 
 Offer lightweight, generally useful agent skills that improve onboarding and execution quality across most repos.
 
@@ -1475,7 +1457,7 @@ MCP servers:
 - Firecrawl: <installed | installed + key | already installed | skipped>
 ```
 
-Use tracking variables from Step 4c to determine status:
+Use tracking variables from Step 4b to determine status:
 - "installed" — installed this session without API key/token
 - "installed + key/token" — installed this session with credentials configured
 - "already installed" — was already present before setup
@@ -1503,7 +1485,7 @@ Desktop applications (<OS_TYPE>):
 - Granola: <installed | already installed | skipped>
 ```
 
-Use tracking variables from Step 4d to determine status. Only show apps compatible with user's OS:
+Use tracking variables from Step 4c to determine status. Only show apps compatible with user's OS:
 - macOS: show all 5 apps
 - Linux: skip (no compatible apps)
 - Windows: show only Granola
@@ -1525,7 +1507,7 @@ CLI tools:
 - CLI Continues: <installed | already installed | skipped>
 ```
 
-Use tracking variables from Step 4e. If gh was already installed before setup, show "already installed".
+Use tracking variables from Step 4d. If gh was already installed before setup, show "already installed".
 
 **Agent skills section** (only show if offered):
 
@@ -1538,7 +1520,7 @@ Agent skills:
 - X Research Skill: <installed | already installed | skipped | failed>
 ```
 
-Use tracking variables from Step 4f.
+Use tracking variables from Step 4e.
 
 Continue summary:
 
@@ -1574,7 +1556,6 @@ Documentation updated:
 Notes:
 - Re-run /flux:setup after plugin updates to refresh scripts
 - Interested in autonomous mode? Run /flux:ralph-init
-- Default skill bootstrap: claudeception (installed if missing)
 - Optional agent skills can be installed/updated via /flux:setup
 - MCP servers installed at user scope are available in all projects
 - Desktop apps and CLI tools are optional productivity boosters


### PR DESCRIPTION
## Summary
- Remove Claudeception — it was installed by setup but never invoked by any Flux workflow
- Port its one unique capability (skill extraction from sessions) into `flux-reflect`, which already handles post-session knowledge capture
- Clean up all references from setup workflow, README, commands-reference, and recommendation scripts

## Test plan
- [ ] Run `/flux:reflect` and verify skill extraction flow works (trigger: "save this as a skill")
- [ ] Run `/flux:setup` and confirm Claudeception is no longer offered
- [ ] Verify no remaining claudeception references outside CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)