### PR TITLE
fix: harden reviews against AI sycophancy

### DIFF
--- a/skills/flux-epic-review/workflow.md
+++ b/skills/flux-epic-review/workflow.md
@@ -372,18 +372,43 @@ git diff ${DIFF_BASE}..HEAD --stat > /tmp/adversarial-stat.txt
 EPIC_SPEC="$($FLUXCTL cat "$EPIC_ID")"
 ```
 
+### Step 1.5: Load Brain Vault Rules
+
+Load project-specific rules that both reviewers must evaluate against:
+
+```bash
+# Load principles (non-negotiable project rules)
+PRINCIPLES=$(cat brain/principles/*.md 2>/dev/null)
+
+# Load pitfalls relevant to changed file domains
+PITFALLS=""
+for area in $(git diff ${DIFF_BASE}..HEAD --name-only | sed 's|/.*||' | sort -u); do
+  PITFALLS="${PITFALLS}$(cat brain/pitfalls/${area}/*.md 2>/dev/null)"
+done
+# Fallback: load all pitfalls if no area match
+[ -z "$PITFALLS" ] && PITFALLS=$(cat brain/pitfalls/*.md 2>/dev/null)
+```
+
 ### Step 2: Build Adversarial Review Prompt
 
-Write a prompt that both models receive (identical input):
+Write a prompt that both models receive (identical input). **Both models must receive the same prompt independently — do NOT include one model's output in the other's input.**
 
 ```bash
 cat > /tmp/adversarial-prompt.md << 'ADVEOF'
 ## Adversarial Code Review
 
+**Your job is to find problems, not confirm quality.** A review that finds zero issues is suspicious — scrutinize harder. Do not soften findings, hedge with "this is probably fine", or defer to the author's judgment. If something is wrong, state it directly with evidence. You are an adversary to bad code, not a supporter of the author.
+
 You are reviewing the implementation of epic [EPIC_ID].
 
 ### Epic Spec
 [PASTE EPIC SPEC]
+
+### Project Principles (MUST NOT violate)
+[PASTE $PRINCIPLES if non-empty, otherwise omit this section]
+
+### Known Pitfalls (check specifically for these)
+[PASTE $PITFALLS if non-empty, otherwise omit this section]
 
 ### Diff Statistics
 [PASTE STAT OUTPUT]
@@ -399,6 +424,10 @@ Review this diff for:
 3. **Architecture** - Data flow, clear boundaries, proper abstractions
 4. **Security** - Injection, auth gaps, data exposure
 5. **Tests** - Adequate coverage for new functionality
+6. **Principle violations** - Does the code violate any project principles listed above?
+7. **Known pitfalls** - Does the code repeat any known pitfalls listed above?
+
+A project principle violation is always at least **Major** severity. A repeated known pitfall is always at least **Major** severity.
 
 For each issue found:
 - **ID**: A-1, A-2, etc. (sequential)
@@ -412,6 +441,8 @@ ADVEOF
 ```
 
 ### Step 3: Send to Both Reviewers
+
+**CRITICAL: Independent context.** Each reviewer must form its verdict independently. Do NOT share Reviewer 1's output with Reviewer 2 or vice versa. The consensus merge in Step 4 is where findings are compared — not before. Sharing outputs before independent review creates echo-chamber sycophancy where the second model defers to the first.
 
 **Reviewer 1** (Anthropic model via Codex or RP — uses same backend as spec review):
 ```bash

--- a/skills/flux-impl-review/workflow.md
+++ b/skills/flux-impl-review/workflow.md
@@ -195,6 +195,40 @@ Commits: [COMMIT SUMMARY]
 ## Review Focus
 [USER'S FOCUS AREAS]
 
+## Reviewer Mindset
+
+**Your job is to find problems, not confirm quality.** A review that finds zero issues is suspicious — look harder. Do not soften findings, hedge with "this might be fine", or defer to the author's intent. If something is wrong, say so directly with evidence. You are a reviewer, not a cheerleader.
+
+## Project-Specific Rules
+
+Before reviewing, load project-specific rules from the brain vault. These are hard-won lessons from this codebase — violations are likely real bugs, not style preferences.
+
+```bash
+# Load principles (non-negotiable project rules)
+cat brain/principles/*.md 2>/dev/null
+
+# Load pitfalls relevant to changed file domains
+# Match pitfall subdirectories to changed file paths (frontend/, backend/, api/, etc.)
+for area in $(git diff --name-only ${BASE_COMMIT:-main}..HEAD | sed 's|/.*||' | sort -u); do
+  cat brain/pitfalls/${area}/*.md 2>/dev/null
+done
+
+# Fallback: load all pitfalls if no area match
+ls brain/pitfalls/*/*.md >/dev/null 2>&1 || cat brain/pitfalls/*.md 2>/dev/null
+```
+
+If principles or pitfalls were loaded, add them to the review context:
+
+```
+## Project Principles (MUST NOT violate)
+[PASTE LOADED PRINCIPLES]
+
+## Known Pitfalls (check specifically for these)
+[PASTE LOADED PITFALLS]
+```
+
+Evaluate the code against these project-specific rules IN ADDITION to the standard criteria below. A principle violation is always at least Major severity.
+
 ## Review Criteria
 
 Conduct a John Carmack-level review:


### PR DESCRIPTION
## Summary
Addresses the AI sycophancy problem where RLHF-trained models flip answers 56-61% of the time when challenged (Fanous et al. 2025), making vague "is this code good?" reviews unreliable.

Three targeted changes to both `impl-review` and `epic-review`:

1. **Brain vault loaded into review prompts** — project principles and relevant pitfalls are now explicit evaluation criteria during reviews, not just during implementation. A principle violation is always at least Major severity.

2. **Anti-sycophancy preamble** — review prompts now explicitly instruct: "Your job is to find problems, not confirm quality. A review that finds zero issues is suspicious."

3. **Independent context enforced** — adversarial reviewers are explicitly told not to see each other's output before forming independent verdicts, preventing echo-chamber sycophancy.

## Why this matters
Previously, brain vault rules were loaded during scope (planning) and work (re-anchor), but NOT during reviews. This meant project-specific conventions discovered over time didn't inform code reviews — exactly the gap Dexhorthy's critique identifies. Reviews should judge against predefined project rules, not generic criteria alone.

## Test plan
- [ ] Run `/flux:impl-review` on a branch — verify brain vault principles appear in review prompt
- [ ] Verify anti-sycophancy preamble is present in review output
- [ ] Run `/flux:epic-review` — verify both adversarial reviewers receive principles/pitfalls
- [ ] Confirm reviewers don't share output before consensus merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)