### PR TITLE
feat: optional human review via Critique TUI

### DIFF
--- a/scripts/fluxctl_pkg/config.py
+++ b/scripts/fluxctl_pkg/config.py
@@ -27,6 +27,7 @@ def get_default_config() -> dict:
             "reviewer2": None,
             "bot": None,
             "severities": ["critical", "major"],
+            "humanReview": False,
         },
         "scouts": {"github": False},
         "tracker": {"provider": None, "teamId": None},

--- a/skills/flux-epic-review/workflow.md
+++ b/skills/flux-epic-review/workflow.md
@@ -734,6 +734,40 @@ agent-browser close
 
 ---
 
+## Human Review Phase
+
+**Only runs if `review.humanReview` is `true` in `.flux/config.json`.**
+
+After all automated review passes are complete (spec compliance, adversarial, security, bot self-heal, browser QA, desloppify scan), check config:
+
+```bash
+HUMAN_REVIEW=$($FLUXCTL config get review.humanReview 2>/dev/null || echo "false")
+```
+
+If `HUMAN_REVIEW` is `true`, ask the user:
+
+> **All automated reviews passed.** Want to review the full branch diff yourself before final sign-off?
+
+If the user says yes, print the command and move on immediately (non-blocking):
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Run this in a separate terminal to review the full diff │
+│                                                          │
+│  bunx critique main                                      │
+│                                                          │
+│  Install Critique (requires Bun):                        │
+│  curl -fsSL https://bun.sh/install | bash                │
+│  bun install -g critique                                 │
+└──────────────────────────────────────────────────────────┘
+```
+
+If the user says no, or if `HUMAN_REVIEW` is `false`, skip silently.
+
+**Do NOT wait for the user to finish reviewing. Proceed directly to Learning Capture.**
+
+---
+
 ## Learning Capture Phase
 
 **Always runs after the full pipeline reaches SHIP (or after max iterations).**

--- a/skills/flux-impl-review/SKILL.md
+++ b/skills/flux-impl-review/SKILL.md
@@ -162,6 +162,40 @@ If verdict is NEEDS_WORK, loop internally until SHIP:
 
 ---
 
+## Human Review (After SHIP)
+
+**Only runs if `review.humanReview` is `true` in `.flux/config.json`.**
+
+After the reviewer returns `<verdict>SHIP</verdict>`, check config:
+
+```bash
+HUMAN_REVIEW=$($FLUXCTL config get review.humanReview 2>/dev/null || echo "false")
+```
+
+If `HUMAN_REVIEW` is `true`, ask the user:
+
+> **Review passed — SHIP.** Want to review the diff yourself before moving on?
+
+If the user says yes, print the command and move on immediately (non-blocking):
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Run this in a separate terminal to review the diff │
+│                                                     │
+│  bunx critique ${BASE_COMMIT:-main}                 │
+│                                                     │
+│  Install Critique (requires Bun):                   │
+│  curl -fsSL https://bun.sh/install | bash           │
+│  bun install -g critique                            │
+└─────────────────────────────────────────────────────┘
+```
+
+If the user says no, or if `HUMAN_REVIEW` is `false`, skip silently.
+
+**Do NOT wait for the user to finish reviewing. Move on immediately.**
+
+---
+
 ## Update Check (End of Command)
 
 **ALWAYS run at the very end of /flux:impl-review execution:**

--- a/skills/flux-setup/workflow.md
+++ b/skills/flux-setup/workflow.md
@@ -1094,6 +1094,23 @@ Then ask for their Linear API key (needed for automated sync of epics/tasks to L
 }
 ```
 
+**Human review question** (include if review backend is NOT "None"):
+```json
+{
+  "header": "Human Review (Optional)",
+  "question": "After AI reviews finish, want to review diffs yourself in the terminal? Uses Critique — a beautiful TUI diff viewer with syntax highlighting and split view. Requires Bun.",
+  "options": [
+    {"label": "Yes", "description": "After each review, Flux prints the command to open the diff in Critique. Non-blocking — you review in a separate terminal."},
+    {"label": "No", "description": "Skip human review. AI reviews only."}
+  ],
+  "multiSelect": false
+}
+```
+
+Save to config:
+- "Yes" → `$FLUXCTL config set review.humanReview true`
+- "No" → `$FLUXCTL config set review.humanReview false`
+
 **Adversarial Reviewer 1 question** (include if review backend is NOT "None"):
 ```json
 {


### PR DESCRIPTION
## Summary
- Engineers can opt-in to reviewing diffs themselves after AI reviews complete, using [Critique](https://github.com/remorses/critique) — a terminal TUI with syntax highlighting, split view, and word-level diffs
- New `review.humanReview` config key (opt-in during `/flux:setup`)
- After impl-review SHIP or all epic-review passes, Flux asks if you want to review and prints the command to run in a separate terminal
- Fully non-blocking — Flux moves on immediately, you review at your own pace

## Files changed
- `scripts/fluxctl_pkg/config.py` — add `humanReview` default to config schema
- `skills/flux-setup/workflow.md` — add human review opt-in question
- `skills/flux-impl-review/SKILL.md` — add human review phase after SHIP
- `skills/flux-epic-review/workflow.md` — add human review phase after all automated passes

## Test plan
- [ ] Run `/flux:setup` — verify human review question appears after review backend selection
- [ ] Run `/flux:impl-review` with `humanReview: true` — verify prompt appears after SHIP
- [ ] Run `/flux:impl-review` with `humanReview: false` — verify no prompt
- [ ] Verify printed `bunx critique` command works in a separate terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)