### PR TITLE
docs: fix CONTRIBUTING.md workflow instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,14 @@ We welcome contributions, but we have **strict requirements** designed to filter
 
 ### 1. You MUST use Flux
 
-You must use Flux to help build Flux. Dogfood the product. Run `/flux:scope` to plan your feature, `/flux:work` to execute tasks, `/flux:impl-review` to check your work. If you're not using Flux to contribute to Flux, you're not a real contributor.
+You must use Flux to help build Flux. Dogfood the product. The workflow is:
+
+1. **`/flux:scope`** — Plan your feature (decomposes into tasks with specs)
+2. **`/flux:work`** — Execute tasks (implementation + impl-review + epic-review all run automatically within this command)
+
+That's it. Two commands. `/flux:work` handles the full loop: implement → test → impl-review → fix until SHIP → next task → epic-review when all tasks are done. You don't need to invoke reviews manually.
+
+If you're not using Flux to contribute to Flux, you're not a real contributor.
 
 ### 2. You MUST export and link your conversation history
 
@@ -61,7 +68,7 @@ Your PR description must include:
 [Link to your social media post about this contribution]
 
 ## Checklist
-- [ ] I used Flux to build this
+- [ ] I used `/flux:scope` + `/flux:work` to build this
 - [ ] I exported and linked my conversation history
 - [ ] I included a demo video
 - [ ] I posted to social media and linked it above


### PR DESCRIPTION
Updated to reflect the actual two-command workflow (`/flux:scope` + `/flux:work`) instead of listing `/flux:impl-review` as a separate manual step.