### PR TITLE
docs: remove non-compatible tools from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,6 @@ Every PR must include a link to the exported conversation(s) that helped you imp
 
 **How to export:**
 - Claude Code: Use `/export` or copy the conversation
-- Cursor: Export chat history
-- Other tools: Screenshot or export however you can
 
 Upload to a gist, paste.gg, or include in the PR description.
 


### PR DESCRIPTION
Removed Cursor and 'other tools' from conversation export instructions — Flux only works with Claude Code.