### PR TITLE
fix: correct install instructions across codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,7 @@ All notable changes to Flux will be documented in this file.
 
 ### Fixed
 
-- **Safe upgrade path unified** — all update prompts now use `/plugin add https://github.com/Nairon-AI/flux@latest`
+- **Safe upgrade path unified** — all update prompts now use `/plugin install flux@nairon-flux`
   - Prevents stale guidance from older `/plugin marketplace update ...` instructions
   - Keeps upgrade behavior consistent with install behavior
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Ship with confidence. Sleep better at night.
 
 | Agent | Status | Install |
 |-------|--------|---------|
-| [Claude Code](https://claude.ai/code) | ✅ Recommended | `/plugin add https://github.com/Nairon-AI/flux@latest` |
+| [Claude Code](https://claude.ai/code) | ✅ Recommended | See install steps below |
 | [OpenCode](https://github.com/anomalyco/opencode) | `[██████████░] 96%` | [flux-opencode](https://github.com/Nairon-AI/flux-opencode) |
 
 **Install** — paste this into your agent:
@@ -94,12 +94,16 @@ After setup, just talk to the agent. Flux parses your message intent and routes 
 
 1. Tell the user to run in their agent UI:
    ```
-   /plugin add https://github.com/Nairon-AI/flux@latest
+   /plugin marketplace add https://github.com/Nairon-AI/flux
    ```
-2. Tell the user to restart their agent/session with `--resume` to pick up where they left off.
-3. After restart, run `/flux:setup` to scaffold `.flux/` and configure preferences.
-4. If setup installs new MCP servers, tell the user to restart with `--resume` once more.
-5. After restart, run `/flux:prime` if the repo hasn't been primed yet.
+2. Then tell the user to install the plugin:
+   ```
+   /plugin install flux@nairon-flux
+   ```
+3. Tell the user to restart their agent/session with `--resume` to pick up where they left off.
+4. After restart, run `/flux:setup` to scaffold `.flux/` and configure preferences.
+5. If setup installs new MCP servers, tell the user to restart with `--resume` once more.
+6. After restart, run `/flux:prime` if the repo hasn't been primed yet.
 
 For **OpenCode**, use the [flux-opencode](https://github.com/Nairon-AI/flux-opencode) port instead.
 
@@ -110,7 +114,7 @@ The `/plugin update` command resolves from a stale marketplace cache. **Do not u
 1. Tell the user to run in their agent UI:
    ```
    /plugin uninstall flux@nairon-flux
-   /plugin add https://github.com/Nairon-AI/flux@latest
+   /plugin install flux@nairon-flux
    ```
 2. Tell the user to restart their agent/session with `--resume`.
 3. Run `/flux:setup` to refresh local scripts if needed.
@@ -512,7 +516,7 @@ Clear cache and reinstall:
 ```bash
 rm -rf ~/.claude/plugins/cache/nairon-flux ~/.claude/plugins/marketplaces/nairon-flux
 ```
-Restart Claude Code, run `/plugin add https://github.com/Nairon-AI/flux@latest`, restart again.
+Restart Claude Code, run `/plugin marketplace add https://github.com/Nairon-AI/flux`, then `/plugin install flux@nairon-flux`, restart again.
 </details>
 
 <details>
@@ -521,13 +525,7 @@ Restart Claude Code, run `/plugin add https://github.com/Nairon-AI/flux@latest`,
 ```bash
 rm -rf ~/.claude/plugins/cache/nairon-flux
 ```
-Restart, run `/plugin add https://github.com/Nairon-AI/flux@latest`, restart again.
-</details>
-
-<details>
-<summary><strong>"/plugin add" opens Discover tab instead of installing</strong></summary>
-
-Run `/plugin marketplace add https://github.com/Nairon-AI/flux`, then `/plugin install flux@nairon-flux`, then restart.
+Restart, run `/plugin uninstall flux@nairon-flux`, then `/plugin install flux@nairon-flux`, restart again.
 </details>
 
 <details>
@@ -538,7 +536,7 @@ rm -rf ~/.claude/plugins/cache/nairon-flux ~/.claude/plugins/marketplaces/nairon
 # Edit ~/.claude/plugins/installed_plugins.json — remove "nairon-flux" entries
 # Edit ~/.claude/settings.json — remove "flux@nairon-flux" from enabledPlugins
 ```
-Restart Claude Code, run `/plugin add https://github.com/Nairon-AI/flux@latest`, restart, run `/flux:setup`.
+Restart Claude Code, run `/plugin marketplace add https://github.com/Nairon-AI/flux`, then `/plugin install flux@nairon-flux`, restart, run `/flux:setup`.
 </details>
 
 **Still stuck?** Join [Discord](https://discord.gg/CEQMd6fmXk) or open a [GitHub issue](https://github.com/Nairon-AI/flux/issues).

--- a/commands/flux/improve.md
+++ b/commands/flux/improve.md
@@ -14,7 +14,7 @@ UPDATE_INFO=$("${CLAUDE_PLUGIN_ROOT:-${DROID_PLUGIN_ROOT}}/scripts/version-check
 
 If `update_available` is true, print once at the start:
 ```
-📦 Flux update available (vLOCAL → vREMOTE). Run: /plugin add https://github.com/Nairon-AI/flux@latest
+📦 Flux update available (vLOCAL → vREMOTE). Run: /plugin install flux@nairon-flux
 ```
 
 Then continue with the command. Do NOT block or prompt - just inform.

--- a/commands/flux/meditate.md
+++ b/commands/flux/meditate.md
@@ -14,7 +14,7 @@ UPDATE_INFO=$("${CLAUDE_PLUGIN_ROOT:-${DROID_PLUGIN_ROOT}}/scripts/version-check
 
 If `update_available` is true, print once at the start:
 ```
-Flux update available (vLOCAL -> vREMOTE). Run: /plugin add https://github.com/Nairon-AI/flux@latest
+Flux update available (vLOCAL -> vREMOTE). Run: /plugin install flux@nairon-flux
 ```
 
 Then continue with the command. Do NOT block or prompt - just inform.

--- a/commands/flux/plan.md
+++ b/commands/flux/plan.md
@@ -14,7 +14,7 @@ UPDATE_INFO=$("${CLAUDE_PLUGIN_ROOT:-${DROID_PLUGIN_ROOT}}/scripts/version-check
 
 If `update_available` is true, print once at the start:
 ```
-📦 Flux update available (vLOCAL → vREMOTE). Run: /plugin add https://github.com/Nairon-AI/flux@latest
+📦 Flux update available (vLOCAL → vREMOTE). Run: /plugin install flux@nairon-flux
 ```
 
 Then continue with the command. Do NOT block or prompt - just inform.

--- a/commands/flux/prime.md
+++ b/commands/flux/prime.md
@@ -14,7 +14,7 @@ UPDATE_INFO=$("${CLAUDE_PLUGIN_ROOT:-${DROID_PLUGIN_ROOT}}/scripts/version-check
 
 If `update_available` is true, print once at the start:
 ```
-📦 Flux update available (vLOCAL → vREMOTE). Run: /plugin add https://github.com/Nairon-AI/flux@latest
+📦 Flux update available (vLOCAL → vREMOTE). Run: /plugin install flux@nairon-flux
 ```
 
 Then continue with the command. Do NOT block or prompt - just inform.

--- a/commands/flux/profile.md
+++ b/commands/flux/profile.md
@@ -14,7 +14,7 @@ UPDATE_INFO=$("${CLAUDE_PLUGIN_ROOT:-${DROID_PLUGIN_ROOT}}/scripts/version-check
 
 If `update_available` is true, print once at the start:
 ```
-📦 Flux update available (vLOCAL -> vREMOTE). Run: /plugin add https://github.com/Nairon-AI/flux@latest
+📦 Flux update available (vLOCAL -> vREMOTE). Run: /plugin install flux@nairon-flux
 ```
 
 Then continue with the command. Do NOT block or prompt - just inform.

--- a/commands/flux/reflect.md
+++ b/commands/flux/reflect.md
@@ -14,7 +14,7 @@ UPDATE_INFO=$("${CLAUDE_PLUGIN_ROOT:-${DROID_PLUGIN_ROOT}}/scripts/version-check
 
 If `update_available` is true, print once at the start:
 ```
-Flux update available (vLOCAL -> vREMOTE). Run: /plugin add https://github.com/Nairon-AI/flux@latest
+Flux update available (vLOCAL -> vREMOTE). Run: /plugin install flux@nairon-flux
 ```
 
 Then continue with the command. Do NOT block or prompt - just inform.

--- a/commands/flux/ruminate.md
+++ b/commands/flux/ruminate.md
@@ -14,7 +14,7 @@ UPDATE_INFO=$("${CLAUDE_PLUGIN_ROOT:-${DROID_PLUGIN_ROOT}}/scripts/version-check
 
 If `update_available` is true, print once at the start:
 ```
-Flux update available (vLOCAL -> vREMOTE). Run: /plugin add https://github.com/Nairon-AI/flux@latest
+Flux update available (vLOCAL -> vREMOTE). Run: /plugin install flux@nairon-flux
 ```
 
 Then continue with the command. Do NOT block or prompt - just inform.

--- a/commands/flux/security-review.md
+++ b/commands/flux/security-review.md
@@ -14,7 +14,7 @@ UPDATE_INFO=$("${CLAUDE_PLUGIN_ROOT:-${DROID_PLUGIN_ROOT}}/scripts/version-check
 
 If `update_available` is true, print once at the start:
 ```
-Flux update available (vLOCAL -> vREMOTE). Run: /plugin add https://github.com/Nairon-AI/flux@latest
+Flux update available (vLOCAL -> vREMOTE). Run: /plugin install flux@nairon-flux
 ```
 
 Then continue with the command. Do NOT block or prompt - just inform.

--- a/commands/flux/security-scan.md
+++ b/commands/flux/security-scan.md
@@ -14,7 +14,7 @@ UPDATE_INFO=$("${CLAUDE_PLUGIN_ROOT:-${DROID_PLUGIN_ROOT}}/scripts/version-check
 
 If `update_available` is true, print once at the start:
 ```
-Flux update available (vLOCAL -> vREMOTE). Run: /plugin add https://github.com/Nairon-AI/flux@latest
+Flux update available (vLOCAL -> vREMOTE). Run: /plugin install flux@nairon-flux
 ```
 
 Then continue with the command. Do NOT block or prompt - just inform.

--- a/commands/flux/threat-model.md
+++ b/commands/flux/threat-model.md
@@ -14,7 +14,7 @@ UPDATE_INFO=$("${CLAUDE_PLUGIN_ROOT:-${DROID_PLUGIN_ROOT}}/scripts/version-check
 
 If `update_available` is true, print once at the start:
 ```
-Flux update available (vLOCAL -> vREMOTE). Run: /plugin add https://github.com/Nairon-AI/flux@latest
+Flux update available (vLOCAL -> vREMOTE). Run: /plugin install flux@nairon-flux
 ```
 
 Then continue with the command. Do NOT block or prompt - just inform.

--- a/commands/flux/vuln-validate.md
+++ b/commands/flux/vuln-validate.md
@@ -14,7 +14,7 @@ UPDATE_INFO=$("${CLAUDE_PLUGIN_ROOT:-${DROID_PLUGIN_ROOT}}/scripts/version-check
 
 If `update_available` is true, print once at the start:
 ```
-Flux update available (vLOCAL -> vREMOTE). Run: /plugin add https://github.com/Nairon-AI/flux@latest
+Flux update available (vLOCAL -> vREMOTE). Run: /plugin install flux@nairon-flux
 ```
 
 Then continue with the command. Do NOT block or prompt - just inform.

--- a/commands/flux/work.md
+++ b/commands/flux/work.md
@@ -14,7 +14,7 @@ UPDATE_INFO=$("${CLAUDE_PLUGIN_ROOT:-${DROID_PLUGIN_ROOT}}/scripts/version-check
 
 If `update_available` is true, print once at the start:
 ```
-📦 Flux update available (vLOCAL → vREMOTE). Run: /plugin add https://github.com/Nairon-AI/flux@latest
+📦 Flux update available (vLOCAL → vREMOTE). Run: /plugin install flux@nairon-flux
 ```
 
 Then continue with the command. Do NOT block or prompt - just inform.

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -16,7 +16,7 @@ Flux is designed to route from intent. In normal use, you should be able to tell
 
 ```bash
 # Claude Code (recommended)
-/plugin add https://github.com/Nairon-AI/flux@latest
+/plugin install flux@nairon-flux
 ```
 
 Important: `/plugin add` is a Claude Code slash command. Run it in Claude Code chat input, not in your terminal.

--- a/docs/contributor-feedback-loop.md
+++ b/docs/contributor-feedback-loop.md
@@ -20,7 +20,7 @@ This project is being used to test the Flux plugin.
    - Make the minimal fix
    - Push and create PR with `gh pr create`
 3. Report the PR URL so it can be reviewed and merged
-4. After merge, upgrade: `/plugin add https://github.com/Nairon-AI/flux@latest`
+4. After merge, upgrade: `/plugin install flux@nairon-flux`
 
 **What counts as a Flux bug:**
 - Command fails unexpectedly
@@ -41,7 +41,7 @@ This project is being used to test the Flux plugin.
 /flux:contribute "Description of the issue"
 
 # After PR is merged, upgrade
-/plugin add https://github.com/Nairon-AI/flux@latest
+/plugin install flux@nairon-flux
 ```
 
 ## Workflow Diagram

--- a/docs/shared/update-check.md
+++ b/docs/shared/update-check.md
@@ -14,7 +14,7 @@ UPDATE_AVAILABLE=$(echo "$UPDATE_JSON" | jq -r '.update_available')
 ```
 ---
 Flux update available: vX.Y.Z → vA.B.C
-Run: /plugin add https://github.com/Nairon-AI/flux@latest
+Run: /plugin install flux@nairon-flux
 Then restart Claude Code for changes to take effect.
 ---
 ```

--- a/scripts/version-check.sh
+++ b/scripts/version-check.sh
@@ -48,6 +48,6 @@ cat << EOJSON
   "local_version": "$LOCAL_VERSION",
   "remote_version": "${REMOTE_VERSION:-unknown}",
   "update_available": $UPDATE_AVAILABLE,
-  "update_command": "/plugin add https://github.com/Nairon-AI/flux@latest"
+  "update_command": "/plugin install flux@nairon-flux"
 }
 EOJSON

--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -473,7 +473,7 @@ REMOTE_VER=$(echo "$UPDATE_JSON" | jq -r '.remote_version')
 ```
 ---
 Flux update available: v${LOCAL_VER} → v${REMOTE_VER}
-Run: /plugin uninstall flux@nairon-flux && /plugin add https://github.com/Nairon-AI/flux@latest
+Run: /plugin uninstall flux@nairon-flux && /plugin install flux@nairon-flux
 Then restart Claude Code for changes to take effect.
 ---
 ```

--- a/skills/flux-contribute/SKILL.md
+++ b/skills/flux-contribute/SKILL.md
@@ -172,7 +172,7 @@ $FIX_DESCRIPTION
 - [ ] Checked for regressions
 
 ## How to Verify
-1. Upgrade: \`/plugin uninstall flux@nairon-flux && /plugin add https://github.com/Nairon-AI/flux@latest\`
+1. Upgrade: \`/plugin uninstall flux@nairon-flux && /plugin install flux@nairon-flux\`
 2. Test: $VERIFICATION_STEPS
 
 ---
@@ -188,7 +188,7 @@ Show:
   ```
   Once merged, upgrade with:
   /plugin uninstall flux@nairon-flux
-  /plugin add https://github.com/Nairon-AI/flux@latest
+  /plugin install flux@nairon-flux
   ```
 
 ## Hard Rules
@@ -235,7 +235,7 @@ REMOTE_VER=$(echo "$UPDATE_JSON" | jq -r '.remote_version')
 ```
 ---
 Flux update available: v${LOCAL_VER} → v${REMOTE_VER}
-Run: /plugin uninstall flux@nairon-flux && /plugin add https://github.com/Nairon-AI/flux@latest
+Run: /plugin uninstall flux@nairon-flux && /plugin install flux@nairon-flux
 Then restart Claude Code for changes to take effect.
 ---
 ```

--- a/skills/flux-deps/SKILL.md
+++ b/skills/flux-deps/SKILL.md
@@ -189,7 +189,7 @@ REMOTE_VER=$(echo "$UPDATE_JSON" | jq -r '.remote_version')
 ```
 ---
 Flux update available: v${LOCAL_VER} → v${REMOTE_VER}
-Run: /plugin uninstall flux@nairon-flux && /plugin add https://github.com/Nairon-AI/flux@latest
+Run: /plugin uninstall flux@nairon-flux && /plugin install flux@nairon-flux
 Then restart Claude Code for changes to take effect.
 ---
 ```

--- a/skills/flux-desloppify/SKILL.md
+++ b/skills/flux-desloppify/SKILL.md
@@ -174,7 +174,7 @@ REMOTE_VER=$(echo "$UPDATE_JSON" | jq -r '.remote_version')
 ```
 ---
 Flux update available: v${LOCAL_VER} → v${REMOTE_VER}
-Run: /plugin uninstall flux@nairon-flux && /plugin add https://github.com/Nairon-AI/flux@latest
+Run: /plugin uninstall flux@nairon-flux && /plugin install flux@nairon-flux
 Then restart Claude Code for changes to take effect.
 ---
 ```

--- a/skills/flux-epic-review/SKILL.md
+++ b/skills/flux-epic-review/SKILL.md
@@ -394,7 +394,7 @@ REMOTE_VER=$(echo "$UPDATE_JSON" | jq -r '.remote_version')
 ```
 ---
 Flux update available: v${LOCAL_VER} → v${REMOTE_VER}
-Run: /plugin uninstall flux@nairon-flux && /plugin add https://github.com/Nairon-AI/flux@latest
+Run: /plugin uninstall flux@nairon-flux && /plugin install flux@nairon-flux
 Then restart Claude Code for changes to take effect.
 ---
 ```

--- a/skills/flux-export-context/SKILL.md
+++ b/skills/flux-export-context/SKILL.md
@@ -141,7 +141,7 @@ REMOTE_VER=$(echo "$UPDATE_JSON" | jq -r '.remote_version')
 ```
 ---
 Flux update available: v${LOCAL_VER} → v${REMOTE_VER}
-Run: /plugin uninstall flux@nairon-flux && /plugin add https://github.com/Nairon-AI/flux@latest
+Run: /plugin uninstall flux@nairon-flux && /plugin install flux@nairon-flux
 Then restart Claude Code for changes to take effect.
 ---
 ```

--- a/skills/flux-impl-review/SKILL.md
+++ b/skills/flux-impl-review/SKILL.md
@@ -214,7 +214,7 @@ REMOTE_VER=$(echo "$UPDATE_JSON" | jq -r '.remote_version')
 ```
 ---
 Flux update available: v${LOCAL_VER} → v${REMOTE_VER}
-Run: /plugin uninstall flux@nairon-flux && /plugin add https://github.com/Nairon-AI/flux@latest
+Run: /plugin uninstall flux@nairon-flux && /plugin install flux@nairon-flux
 Then restart Claude Code for changes to take effect.
 ---
 ```

--- a/skills/flux-improve/SKILL.md
+++ b/skills/flux-improve/SKILL.md
@@ -107,7 +107,7 @@ REMOTE_VER=$(echo "$UPDATE_JSON" | jq -r '.remote_version')
 ```
 ---
 Flux update available: v${LOCAL_VER} → v${REMOTE_VER}
-Run: /plugin uninstall flux@nairon-flux && /plugin add https://github.com/Nairon-AI/flux@latest
+Run: /plugin uninstall flux@nairon-flux && /plugin install flux@nairon-flux
 Then restart Claude Code for changes to take effect.
 ---
 ```

--- a/skills/flux-plan-review/SKILL.md
+++ b/skills/flux-plan-review/SKILL.md
@@ -199,7 +199,7 @@ REMOTE_VER=$(echo "$UPDATE_JSON" | jq -r '.remote_version')
 ```
 ---
 Flux update available: v${LOCAL_VER} → v${REMOTE_VER}
-Run: /plugin uninstall flux@nairon-flux && /plugin add https://github.com/Nairon-AI/flux@latest
+Run: /plugin uninstall flux@nairon-flux && /plugin install flux@nairon-flux
 Then restart Claude Code for changes to take effect.
 ---
 ```

--- a/skills/flux-plan/SKILL.md
+++ b/skills/flux-plan/SKILL.md
@@ -207,7 +207,7 @@ REMOTE_VER=$(echo "$UPDATE_JSON" | jq -r '.remote_version')
 ```
 ---
 Flux update available: v${LOCAL_VER} → v${REMOTE_VER}
-Run: /plugin uninstall flux@nairon-flux && /plugin add https://github.com/Nairon-AI/flux@latest
+Run: /plugin uninstall flux@nairon-flux && /plugin install flux@nairon-flux
 Then restart Claude Code for changes to take effect.
 ---
 ```

--- a/skills/flux-prime/SKILL.md
+++ b/skills/flux-prime/SKILL.md
@@ -153,7 +153,7 @@ REMOTE_VER=$(echo "$UPDATE_JSON" | jq -r '.remote_version')
 ```
 ---
 Flux update available: v${LOCAL_VER} → v${REMOTE_VER}
-Run: /plugin uninstall flux@nairon-flux && /plugin add https://github.com/Nairon-AI/flux@latest
+Run: /plugin uninstall flux@nairon-flux && /plugin install flux@nairon-flux
 Then restart Claude Code for changes to take effect.
 ---
 ```

--- a/skills/flux-profile/SKILL.md
+++ b/skills/flux-profile/SKILL.md
@@ -88,7 +88,7 @@ REMOTE_VER=$(echo "$UPDATE_JSON" | jq -r '.remote_version')
 ```
 ---
 Flux update available: v${LOCAL_VER} → v${REMOTE_VER}
-Run: /plugin uninstall flux@nairon-flux && /plugin add https://github.com/Nairon-AI/flux@latest
+Run: /plugin uninstall flux@nairon-flux && /plugin install flux@nairon-flux
 Then restart Claude Code for changes to take effect.
 ---
 ```

--- a/skills/flux-propose/SKILL.md
+++ b/skills/flux-propose/SKILL.md
@@ -338,7 +338,7 @@ REMOTE_VER=$(echo "$UPDATE_JSON" | jq -r '.remote_version')
 ```
 ---
 Flux update available: v${LOCAL_VER} → v${REMOTE_VER}
-Run: /plugin uninstall flux@nairon-flux && /plugin add https://github.com/Nairon-AI/flux@latest
+Run: /plugin uninstall flux@nairon-flux && /plugin install flux@nairon-flux
 Then restart Claude Code for changes to take effect.
 ---
 ```

--- a/skills/flux-ralph-init/SKILL.md
+++ b/skills/flux-ralph-init/SKILL.md
@@ -133,7 +133,7 @@ REMOTE_VER=$(echo "$UPDATE_JSON" | jq -r '.remote_version')
 ```
 ---
 Flux update available: v${LOCAL_VER} → v${REMOTE_VER}
-Run: /plugin uninstall flux@nairon-flux && /plugin add https://github.com/Nairon-AI/flux@latest
+Run: /plugin uninstall flux@nairon-flux && /plugin install flux@nairon-flux
 Then restart Claude Code for changes to take effect.
 ---
 ```

--- a/skills/flux-rca/SKILL.md
+++ b/skills/flux-rca/SKILL.md
@@ -414,7 +414,7 @@ REMOTE_VER=$(echo "$UPDATE_JSON" | jq -r '.remote_version')
 ```
 ---
 Flux update available: v${LOCAL_VER} → v${REMOTE_VER}
-Run: /plugin uninstall flux@nairon-flux && /plugin add https://github.com/Nairon-AI/flux@latest
+Run: /plugin uninstall flux@nairon-flux && /plugin install flux@nairon-flux
 Then restart Claude Code for changes to take effect.
 ---
 ```

--- a/skills/flux-rp-explorer/SKILL.md
+++ b/skills/flux-rp-explorer/SKILL.md
@@ -87,7 +87,7 @@ REMOTE_VER=$(echo "$UPDATE_JSON" | jq -r '.remote_version')
 ```
 ---
 Flux update available: v${LOCAL_VER} → v${REMOTE_VER}
-Run: /plugin uninstall flux@nairon-flux && /plugin add https://github.com/Nairon-AI/flux@latest
+Run: /plugin uninstall flux@nairon-flux && /plugin install flux@nairon-flux
 Then restart Claude Code for changes to take effect.
 ---
 ```

--- a/skills/flux-scope/completion.md
+++ b/skills/flux-scope/completion.md
@@ -110,7 +110,7 @@ REMOTE_VER=$(echo "$UPDATE_JSON" | jq -r '.remote_version')
 ```
 ---
 Flux update available: v${LOCAL_VER} → v${REMOTE_VER}
-Run: /plugin uninstall flux@nairon-flux && /plugin add https://github.com/Nairon-AI/flux@latest
+Run: /plugin uninstall flux@nairon-flux && /plugin install flux@nairon-flux
 Then restart Claude Code for changes to take effect.
 ---
 ```

--- a/skills/flux-setup/SKILL.md
+++ b/skills/flux-setup/SKILL.md
@@ -73,7 +73,7 @@ REMOTE_VER=$(echo "$UPDATE_JSON" | jq -r '.remote_version')
 ```
 ---
 Flux update available: v${LOCAL_VER} → v${REMOTE_VER}
-Run: /plugin uninstall flux@nairon-flux && /plugin add https://github.com/Nairon-AI/flux@latest
+Run: /plugin uninstall flux@nairon-flux && /plugin install flux@nairon-flux
 Then restart Claude Code for changes to take effect.
 ---
 ```

--- a/skills/flux-sync/SKILL.md
+++ b/skills/flux-sync/SKILL.md
@@ -181,7 +181,7 @@ REMOTE_VER=$(echo "$UPDATE_JSON" | jq -r '.remote_version')
 ```
 ---
 Flux update available: v${LOCAL_VER} → v${REMOTE_VER}
-Run: /plugin uninstall flux@nairon-flux && /plugin add https://github.com/Nairon-AI/flux@latest
+Run: /plugin uninstall flux@nairon-flux && /plugin install flux@nairon-flux
 Then restart Claude Code for changes to take effect.
 ---
 ```

--- a/skills/flux-work/SKILL.md
+++ b/skills/flux-work/SKILL.md
@@ -185,7 +185,7 @@ REMOTE_VER=$(echo "$UPDATE_JSON" | jq -r '.remote_version')
 ```
 ---
 Flux update available: v${LOCAL_VER} → v${REMOTE_VER}
-Run: /plugin uninstall flux@nairon-flux && /plugin add https://github.com/Nairon-AI/flux@latest
+Run: /plugin uninstall flux@nairon-flux && /plugin install flux@nairon-flux
 Then restart Claude Code for changes to take effect.
 ---
 ```

--- a/skills/flux-worktree-kit/SKILL.md
+++ b/skills/flux-worktree-kit/SKILL.md
@@ -50,7 +50,7 @@ REMOTE_VER=$(echo "$UPDATE_JSON" | jq -r '.remote_version')
 ```
 ---
 Flux update available: v${LOCAL_VER} → v${REMOTE_VER}
-Run: /plugin uninstall flux@nairon-flux && /plugin add https://github.com/Nairon-AI/flux@latest
+Run: /plugin uninstall flux@nairon-flux && /plugin install flux@nairon-flux
 Then restart Claude Code for changes to take effect.
 ---
 ```

--- a/skills/flux/SKILL.md
+++ b/skills/flux/SKILL.md
@@ -181,7 +181,7 @@ REMOTE_VER=$(echo "$UPDATE_JSON" | jq -r '.remote_version')
 ```
 ---
 Flux update available: v${LOCAL_VER} → v${REMOTE_VER}
-Run: /plugin uninstall flux@nairon-flux && /plugin add https://github.com/Nairon-AI/flux@latest
+Run: /plugin uninstall flux@nairon-flux && /plugin install flux@nairon-flux
 Then restart Claude Code for changes to take effect.
 ---
 ```


### PR DESCRIPTION
## Summary
The old install command (`/plugin add https://github.com/Nairon-AI/flux@latest`) doesn't work — Claude Code requires adding the marketplace first.

**Correct flow:**
1. `/plugin marketplace add https://github.com/Nairon-AI/flux`
2. `/plugin install flux@nairon-flux`

Updated across 40 files: README, all 22 skill update-check messages, commands/, docs/, and version-check.sh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)