### PR TITLE
fix: add marketplace remove to uninstall flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ The `/plugin update` command resolves from a stale marketplace cache. **Do not u
 3. Tell the user to run in their agent UI:
    ```
    /plugin uninstall flux@nairon-flux
+   /plugin marketplace remove nairon-flux
    ```
 4. Remove project artifacts (the agent does this, not the user):
    ```bash


### PR DESCRIPTION
Uninstall instructions now include `/plugin marketplace remove nairon-flux` so the marketplace entry is cleaned up too.