### PR TITLE
fix: bump plugin version to 2.3.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "2.0.5-dev",
+  "version": "2.3.1",
   "description": "AI-native capability benchmarking with structured SDLC workflow. Measures interview depth, pushback ratio, prompt quality, and iteration efficiency. Worker subagent per task for context isolation.",
   "author": {
     "name": "NaironAI",

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Flux
 
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/CEQMd6fmXk)
-[![Version](https://img.shields.io/badge/version-v2.2.0-green)](https://github.com/Nairon-AI/flux/releases)
+[![Version](https://img.shields.io/badge/version-v2.3.1-green)](https://github.com/Nairon-AI/flux/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-blueviolet)](https://claude.ai/code)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flux",
-  "version": "2.0.5-dev",
+  "version": "2.3.1",
   "description": "AI-native capability benchmarking and structured SDLC workflow for Claude Code",
   "type": "module",
   "private": true,


### PR DESCRIPTION
package.json and plugin.json were stuck at 2.0.5-dev — users installing via marketplace got the wrong version number.