### PR TITLE
fix: update CHANGELOG.md and prevent version guard failures

### DIFF
--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -3,6 +3,11 @@ name: Version Guard
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      - 'package.json'
+      - '.claude-plugin/plugin.json'
 
 permissions:
   contents: read
@@ -45,7 +50,7 @@ jobs:
           echo "Versions OK: package.json=${PKG_VERSION}, plugin.json=${PLUGIN_VERSION}"
 
       - name: Open issue if guard fails
-        if: failure()
+        if: failure() && github.event_name == 'push'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary
- Backfilled CHANGELOG.md with all releases from v1.9.6 through v2.3.1 (was stuck at v1.9.5)
- `/flux:release` skill now updates CHANGELOG.md as part of every release (moves Unreleased entries into versioned heading)
- Version guard CI now runs on PRs targeting main (catches missing `-dev` suffix before merge, not after)

## Why
CHANGELOG.md hadn't been updated since v1.9.5 — 15 releases were missing. The release skill didn't include it, so it kept falling behind. The version guard only ran post-merge, so bad versions landed on main before being caught.

## Test plan
- [ ] Version Guard check appears on this PR
- [ ] CHANGELOG.md entries match GitHub release notes
- [ ] `/flux:release` skill references CHANGELOG.md in all steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)