### PR TITLE
fix: fluxctl ModuleNotFoundError when installed as plugin

### DIFF
--- a/scripts/fluxctl.py
+++ b/scripts/fluxctl.py
@@ -8,7 +8,7 @@ import sys
 import os
 
 # Ensure the scripts directory is on the path so fluxctl_pkg is importable
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 
 from fluxctl_pkg.__main__ import main
 


### PR DESCRIPTION
## Summary
- `os.path.abspath` → `os.path.realpath` in `scripts/fluxctl.py`
- When `.flux/bin/fluxctl` is a symlink, `abspath` resolves to `.flux/bin/` and Python can't find `fluxctl_pkg`. `realpath` follows the symlink to the plugin's `scripts/` directory.

## Test plan
- [ ] Install Flux as a plugin in a fresh project
- [ ] Run `.flux/bin/fluxctl session-state` — should work without `ModuleNotFoundError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)