### PR TITLE
feat: auto-release on PR merge when fix/feat commits exist

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,153 @@
+name: Auto Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  auto-release:
+    # Skip version bump commits and release commits
+    if: >-
+      !contains(github.event.head_commit.message, '[skip ci]') &&
+      !startsWith(github.event.head_commit.message, 'release:') &&
+      !startsWith(github.event.head_commit.message, 'chore: bump version')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get last release tag
+        id: last_tag
+        run: |
+          TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          if [ -z "$TAG" ]; then
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            echo "No previous release tag found"
+          else
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            echo "Last release: $TAG"
+          fi
+
+      - name: Analyze commits since last release
+        id: analyze
+        run: |
+          TAG="${{ steps.last_tag.outputs.tag }}"
+          if [ -z "$TAG" ]; then
+            RANGE="HEAD"
+          else
+            RANGE="${TAG}..HEAD"
+          fi
+
+          # Collect commit subjects
+          COMMITS=$(git log "$RANGE" --pretty=format:"%s" 2>/dev/null || echo "")
+          if [ -z "$COMMITS" ]; then
+            echo "release_needed=false" >> "$GITHUB_OUTPUT"
+            echo "No commits since last release"
+            exit 0
+          fi
+
+          echo "Commits since $TAG:"
+          echo "$COMMITS"
+
+          # Determine bump type from conventional commits
+          HAS_BREAKING=false
+          HAS_FEAT=false
+          HAS_FIX=false
+
+          while IFS= read -r msg; do
+            if echo "$msg" | grep -qiE '^[a-z]+(\(.+\))?!:' || echo "$msg" | grep -qi 'BREAKING CHANGE'; then
+              HAS_BREAKING=true
+            elif echo "$msg" | grep -qiE '^feat(\(.+\))?:'; then
+              HAS_FEAT=true
+            elif echo "$msg" | grep -qiE '^fix(\(.+\))?:'; then
+              HAS_FIX=true
+            fi
+          done <<< "$COMMITS"
+
+          if $HAS_BREAKING; then
+            echo "bump=major" >> "$GITHUB_OUTPUT"
+            echo "release_needed=true" >> "$GITHUB_OUTPUT"
+            echo "Bump: major (breaking change)"
+          elif $HAS_FEAT; then
+            echo "bump=minor" >> "$GITHUB_OUTPUT"
+            echo "release_needed=true" >> "$GITHUB_OUTPUT"
+            echo "Bump: minor (new feature)"
+          elif $HAS_FIX; then
+            echo "bump=patch" >> "$GITHUB_OUTPUT"
+            echo "release_needed=true" >> "$GITHUB_OUTPUT"
+            echo "Bump: patch (bug fix)"
+          else
+            echo "release_needed=false" >> "$GITHUB_OUTPUT"
+            echo "No releasable commits (only docs/chore/ci)"
+          fi
+
+      - name: Compute next version
+        if: steps.analyze.outputs.release_needed == 'true'
+        id: version
+        run: |
+          TAG="${{ steps.last_tag.outputs.tag }}"
+          BUMP="${{ steps.analyze.outputs.bump }}"
+
+          # Strip 'v' prefix
+          CURRENT="${TAG#v}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+
+          case "$BUMP" in
+            major) NEXT="$((MAJOR + 1)).0.0" ;;
+            minor) NEXT="${MAJOR}.$((MINOR + 1)).0" ;;
+            patch) NEXT="${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
+          esac
+
+          echo "version=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "Next version: $NEXT"
+
+      - name: Bump version in all manifest files
+        if: steps.analyze.outputs.release_needed == 'true'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # 1. package.json
+          jq --arg v "$VERSION" '.version = $v' package.json > tmp && mv tmp package.json
+
+          # 2. plugin.json
+          jq --arg v "$VERSION" '.version = $v' .claude-plugin/plugin.json > tmp && mv tmp .claude-plugin/plugin.json
+
+          # 3. marketplace.json
+          jq --arg v "$VERSION" '.plugins[0].version = $v' .claude-plugin/marketplace.json > tmp && mv tmp .claude-plugin/marketplace.json
+
+          # 4. README badge
+          sed -i "s/version-v[0-9]*\.[0-9]*\.[0-9]*[^-]*/version-v${VERSION}/" README.md
+
+          # 5. CHANGELOG — move [Unreleased] entries under new version heading
+          DATE=$(date +%Y-%m-%d)
+          sed -i "s/## \[Unreleased\]/## [Unreleased]\n\n## [${VERSION}] - ${DATE}/" CHANGELOG.md
+
+      - name: Commit and tag
+        if: steps.analyze.outputs.release_needed == 'true'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json README.md CHANGELOG.md
+          git commit -m "release: v${VERSION} [skip ci]"
+          git tag "v${VERSION}"
+          git push origin main --tags
+
+      - name: Create GitHub release
+        if: steps.analyze.outputs.release_needed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="${{ steps.last_tag.outputs.tag }}"
+          gh release create "v${VERSION}" \
+            --target main \
+            --title "v${VERSION}" \
+            --generate-notes \
+            ${TAG:+--notes-start-tag "$TAG"}


### PR DESCRIPTION
## Summary
- New GitHub Action that triggers on push to main (i.e. PR merge)
- Analyzes commits since last release tag using conventional commit prefixes
- `fix:` → patch bump, `feat:` → minor bump, breaking → major bump
- `docs:`, `chore:`, `ci:`, `style:` → no release
- When release needed: bumps all 5 version files (package.json, plugin.json, marketplace.json, README badge, CHANGELOG), commits, tags, creates GitHub release
- Existing `post-release-bump.yml` then fires to add `-dev` suffix
- Skips its own commits via `[skip ci]` and commit prefix checks

## Flow
```
PR merged → push to main → auto-release checks commits → 
  fix/feat found? → bump versions → commit → tag → GitHub release →
    post-release-bump fires → adds -dev suffix → done
```

## Test plan
- [ ] Merge a PR with a `fix:` commit → should create a patch release
- [ ] Merge a PR with only `docs:` commits → should skip release
- [ ] Verify all 5 version files are updated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)