### PR TITLE
fix: auto-release label error

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -151,8 +151,7 @@ jobs:
             --head "release/v${VERSION}" \
             --base main \
             --title "release: v${VERSION}" \
-            --body "Automated release — bumps version to ${VERSION} in all manifest files." \
-            --label "release")
+            --body "Automated release — bumps version to ${VERSION} in all manifest files.")
 
           # Auto-merge (admin bypass for branch protection)
           gh pr merge "$PR_URL" --squash --admin --delete-branch


### PR DESCRIPTION
Removes `--label release` flag — the label doesn't exist in the repo and was causing the auto-release to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)