### PR TITLE
fix: use RELEASE_TOKEN for release workflows

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Get last release tag
         id: last_tag
@@ -102,7 +102,7 @@ jobs:
       - name: Create tag and GitHub release
         if: steps.analyze.outputs.release_needed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           TAG="${{ steps.last_tag.outputs.tag }}"

--- a/.github/workflows/post-release-bump.yml
+++ b/.github/workflows/post-release-bump.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Compute next dev version
         id: next


### PR DESCRIPTION
## Summary
- `auto-release.yml` and `post-release-bump.yml` now use `secrets.RELEASE_TOKEN` instead of `secrets.GITHUB_TOKEN`
- Org policy blocks `GITHUB_TOKEN` from pushing to protected branches

## Setup required
Add a fine-grained PAT as repo secret `RELEASE_TOKEN` — see PR description below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)