### PR TITLE
fix: correct upgrade steps — don't delete marketplace dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ Install the Flux plugin. Here's the README: https://github.com/Nairon-AI/flux
 
 **Upgrade** — run this in your terminal, then restart Claude Code:
 ```bash
-rm -rf ~/.claude/plugins/cache/nairon-flux ~/.claude/plugins/marketplaces/nairon-flux
+rm -rf ~/.claude/plugins/cache/nairon-flux
+claude plugin marketplace add https://github.com/Nairon-AI/flux
 ```
 Your project setup (`.flux/`, brain vault, CLAUDE.md, MCP servers) is untouched — only the plugin code is refreshed.
 
@@ -110,9 +111,10 @@ Flux uses Claude Code's [plugin system](https://docs.anthropic.com/en/docs/claud
 6. After restart, run `/flux:prime` if the repo hasn't been primed yet.
 
 #### Upgrade
-1. Clear the plugin and marketplace cache so Claude Code re-fetches the latest version on next start:
+1. Clear the plugin cache and refresh the marketplace to pick up the latest version:
    ```bash
-   rm -rf ~/.claude/plugins/cache/nairon-flux ~/.claude/plugins/marketplaces/nairon-flux
+   rm -rf ~/.claude/plugins/cache/nairon-flux
+   claude plugin marketplace add https://github.com/Nairon-AI/flux 2>&1
    ```
 2. Tell the user to restart Claude Code (with `--resume` to keep context).
 3. Project-local files (`.flux/`, brain vault, CLAUDE.md, MCP servers) are not affected.
@@ -522,9 +524,10 @@ Restart Claude Code, run `/plugin marketplace add https://github.com/Nairon-AI/f
 <summary><strong>Old version / missing new commands</strong></summary>
 
 ```bash
-rm -rf ~/.claude/plugins/cache/nairon-flux ~/.claude/plugins/marketplaces/nairon-flux
+rm -rf ~/.claude/plugins/cache/nairon-flux
+claude plugin marketplace add https://github.com/Nairon-AI/flux
 ```
-Restart, run `/plugin uninstall flux@nairon-flux`, then `/plugin add https://github.com/Nairon-AI/flux@latest`, restart again.
+Restart Claude Code.
 </details>
 
 <details>


### PR DESCRIPTION
## Summary
- Previous upgrade instructions deleted `~/.claude/plugins/marketplaces/nairon-flux` which broke plugin registration entirely
- Correct approach: clear code cache + re-add marketplace to refresh metadata
- Updated user-facing upgrade, Plugin CLI Reference, and troubleshooting sections

## Correct upgrade
```bash
rm -rf ~/.claude/plugins/cache/nairon-flux
claude plugin marketplace add https://github.com/Nairon-AI/flux
```
Then restart Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)