### PR TITLE
fix: reliable upgrade instructions with manual fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,14 @@ Ship with confidence. Sleep better at night.
 Install the Flux plugin. Here's the README: https://github.com/Nairon-AI/flux
 ```
 
-**Upgrade** — type `/flux:upgrade` in Claude Code, then `/reload-plugins`. No restart needed. Your project setup is untouched.
+**Upgrade** — type `/flux:upgrade` in Claude Code, then restart with `--resume`. Your project setup (`.flux/`, brain vault, CLAUDE.md) is untouched.
+
+> Don't have `/flux:upgrade` yet? Run these in your **terminal** (not in Claude Code), then restart:
+> ```bash
+> rm -rf ~/.claude/plugins/cache/nairon-flux
+> claude plugin marketplace add https://github.com/Nairon-AI/flux
+> claude plugin install flux@nairon-flux
+> ```
 
 **Uninstall** — say this in Claude Code:
 ```
@@ -106,9 +113,16 @@ Flux uses Claude Code's [plugin system](https://docs.anthropic.com/en/docs/claud
 6. After restart, run `/flux:prime` if the repo hasn't been primed yet.
 
 #### Upgrade
-Run `/flux:upgrade` inside Claude Code. It refreshes the marketplace, clears the plugin cache, and updates the install record automatically. Then run `/reload-plugins` to load the new version — no restart needed.
+**If you have `/flux:upgrade`** (v2.4.0+): run it inside Claude Code, then restart with `--resume`.
 
-Project-local files (`.flux/`, brain vault, CLAUDE.md, MCP servers) are never affected.
+**If you don't have `/flux:upgrade`** (older versions): run these in your terminal, then restart Claude Code:
+```bash
+rm -rf ~/.claude/plugins/cache/nairon-flux
+claude plugin marketplace add https://github.com/Nairon-AI/flux 2>&1
+claude plugin install flux@nairon-flux 2>&1
+```
+
+Project-local files (`.flux/`, brain vault, CLAUDE.md, MCP servers) are never affected by upgrades.
 
 #### Uninstall
 1. Read `.flux/meta.json` for the `installed_by_flux` manifest to see what Flux added.

--- a/skills/flux-upgrade/SKILL.md
+++ b/skills/flux-upgrade/SKILL.md
@@ -89,15 +89,13 @@ jq --arg v "$NEW_VERSION" \
 echo "Install record updated to $NEW_VERSION"
 ```
 
-### Step 6: Reload plugins
+### Step 6: Restart
 
-Tell the user to run `/reload-plugins` to pick up the new version without restarting:
+Tell the user to restart Claude Code to load the new version:
 
 ```
 ✅ Flux upgraded: v{OLD_VERSION} → v{NEW_VERSION}
 
-Run /reload-plugins now to load the new version (no restart needed).
+Restart Claude Code now to load the new version (use --resume to keep context).
 Your project setup (.flux/, brain vault, CLAUDE.md) was not modified.
 ```
-
-If `/reload-plugins` doesn't work or skills seem stale, tell the user to restart Claude Code with `--resume`.


### PR DESCRIPTION
## Summary
- Upgrade now says **restart** (not `/reload-plugins`) — new skills don't register without restart
- Added manual fallback for users on older versions who don't have `/flux:upgrade` yet
- Both README and SKILL.md updated consistently

## What changed
- README: upgrade section has both `/flux:upgrade` path and manual terminal commands
- Plugin CLI Reference: separate instructions for v2.4.0+ vs older versions
- `skills/flux-upgrade/SKILL.md`: Step 6 says restart, not reload-plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)