### PR TITLE
docs: simplify upgrade to just /flux:upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,7 @@ Ship with confidence. Sleep better at night.
 Install the Flux plugin. Here's the README: https://github.com/Nairon-AI/flux
 ```
 
-**Upgrade** — type `/flux:upgrade` in Claude Code, then restart with `--resume`. Your project setup (`.flux/`, brain vault, CLAUDE.md) is untouched.
-
-> Don't have `/flux:upgrade` yet? Run these in your **terminal** (not in Claude Code), then restart:
-> ```bash
-> rm -rf ~/.claude/plugins/cache/nairon-flux
-> claude plugin marketplace add https://github.com/Nairon-AI/flux
-> claude plugin install flux@nairon-flux
-> ```
+**Upgrade** — type `/flux:upgrade` in Claude Code, then restart with `--resume`. Your project setup is untouched.
 
 **Uninstall** — say this in Claude Code:
 ```
@@ -113,16 +106,7 @@ Flux uses Claude Code's [plugin system](https://docs.anthropic.com/en/docs/claud
 6. After restart, run `/flux:prime` if the repo hasn't been primed yet.
 
 #### Upgrade
-**If you have `/flux:upgrade`** (v2.4.0+): run it inside Claude Code, then restart with `--resume`.
-
-**If you don't have `/flux:upgrade`** (older versions): run these in your terminal, then restart Claude Code:
-```bash
-rm -rf ~/.claude/plugins/cache/nairon-flux
-claude plugin marketplace add https://github.com/Nairon-AI/flux 2>&1
-claude plugin install flux@nairon-flux 2>&1
-```
-
-Project-local files (`.flux/`, brain vault, CLAUDE.md, MCP servers) are never affected by upgrades.
+Run `/flux:upgrade` inside Claude Code, then restart with `--resume`. Project-local files (`.flux/`, brain vault, CLAUDE.md, MCP servers) are never affected.
 
 #### Uninstall
 1. Read `.flux/meta.json` for the `installed_by_flux` manifest to see what Flux added.


### PR DESCRIPTION
All users have /flux:upgrade — removed legacy manual fallback steps from both user-facing and CLI reference sections.