### PR TITLE
feat: wire reflect/ruminate/meditate into main workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,17 +197,22 @@ flowchart TD
     ImplReview["Impl Review<br/>(per-task, lightweight)"]
     EpicReview["Epic Review<br/>(per-epic, thorough)"]
     Quality["Quality<br/>(tests + desloppify scan)"]
-    Ship["Ship<br/>(push + PR)"]
+    Submit["Submit<br/>(push + PR)"]
+    Reflect["Reflect<br/>(capture learnings)"]
+    Meditate["Meditate<br/>(prune + promote)"]
+    Ruminate["Ruminate<br/>(mine past sessions)"]
+    Improve["Improve<br/>(recommendations engine)"]
 
     SessionStart --> Pulse
     Pulse -->|"new tools?<br/>nudge /flux:improve"| Prime
-    Pulse -->|"brain bloated?<br/>nudge /flux:meditate"| Prime
     Pulse -->|"all clear"| Prime
-    Prime --> Scope
+    Prime -->|"brain thin +<br/>past sessions exist"| Ruminate
+    Prime -->|"brain ready"| Scope
+    Ruminate -->|"bootstrap brain<br/>from history"| Scope
     Scope -->|"non-technical user<br/>detected"| Propose
     Propose -->|"creates proposal PR<br/>for engineering"| ProposeDone["Proposal Created"]
     Scope -->|"bug detected"| RCA
-    RCA -->|"fix + regression test<br/>+ pitfall written"| Ship
+    RCA -->|"fix + regression test<br/>+ pitfall written"| Submit
     Scope -->|"creates epic + tasks<br/>+ Browser QA checklist"| Work
 
     subgraph task_loop ["Task Loop (per task)"]
@@ -242,26 +247,20 @@ flowchart TD
     EpicReview --> SpecCompliance
     FrustrationSignal -->|"no"| Quality
     FrustrationSignal -->|"yes: suggest<br/>/flux:improve --user-context"| Quality
-    Quality --> Ship
-    Ship -->|"suggest /flux:reflect"| Done["Done"]
+    Quality --> Submit
+    Submit --> Reflect
+    Reflect -->|"20+ pitfall files"| Meditate
+    Reflect -->|"brain healthy"| Done["Done"]
+    Meditate --> Done
 
     Brain["Brain Vault<br/>(pitfalls, principles,<br/>conventions, decisions)"]
 
     Brain -.->|"read: principles +<br/>relevant pitfalls"| Scope
     Brain -.->|"read: re-anchor<br/>per task"| Work
     LearningCapture -.->|"write: pitfalls<br/>by area"| Brain
-
-    subgraph maintenance ["Between Epics"]
-        Reflect["Reflect<br/>(learnings + skills)"]
-        Ruminate["Ruminate<br/>(mine past sessions)"]
-        Meditate["Meditate<br/>(prune + promote)"]
-        Improve["Improve<br/>(recommendations engine)"]
-    end
-
-    Reflect -.->|"write"| Brain
-    Ruminate -.->|"write"| Brain
+    Reflect -.->|"write: learnings<br/>+ skills"| Brain
+    Ruminate -.->|"write: mined<br/>patterns"| Brain
     Meditate -.->|"prune/promote"| Brain
-    Pulse -.->|"nudge when<br/>brain bloated"| Meditate
     Pulse -.->|"nudge when<br/>new tools"| Improve
 ```
 
@@ -269,17 +268,17 @@ flowchart TD
 |-------|-------------|
 | **Session Start** | Startup hook injects brain vault index + workflow state. Recommendation pulse checks for new tools and brain vault health (once/day). |
 | **Prime** | One-time readiness audit: 8 pillars, 48 criteria. Flux detects when needed. |
+| **Ruminate** | *Auto after Prime (first session only):* mines past Claude Code conversations to bootstrap the brain vault when it's empty/thin. Skipped if brain already has content. |
 | **Propose** | Stakeholder feature proposal: conversational planning with engineering pushback, cost/complexity estimates, documented handoff via PR |
 | **RCA** | Bug-specific flow: backward trace from symptom to root cause, adversarial verification, regression test, embedded learnings. Optionally uses RepoPrompt Investigate. |
 | **Scope** | Double Diamond interview: classify work, surface blind spots, create epic with sized tasks |
 | **Work** | Task loop: spawn worker per task with fresh context, brain re-anchor, impl-review after each |
 | **Review** | Per-task lightweight (`impl-review`), per-epic thorough (`epic-review` — adversarial, security, BYORB, browser QA, learning capture) |
 | **Quality** | Tests, lint/format, desloppify scan on changed files |
-| **Ship** | Push, open PR, suggest `/flux:reflect` |
-| | |
-| **Reflect** | *Between epics:* capture session learnings to brain vault and extract reusable skills from the session. Suggested after every ship. |
-| **Ruminate** | *Between epics:* mine past conversations for missed patterns |
-| **Meditate** | *Between epics:* audit brain vault — prune stale notes, promote pitfalls to principles. Auto-nudged when 5+ new pitfalls accumulate or 30+ days since last meditation. |
+| **Submit** | Push + open PR. Code is ready for review/merge. |
+| **Reflect** | *Auto after Submit:* capture session learnings to brain vault and extract reusable skills while context is fresh. |
+| **Meditate** | *Auto after Reflect (conditional):* prune stale notes, promote pitfalls to principles. Triggers when 20+ pitfall files accumulate. |
+| **Ship** | PR merged + deployed (happens outside Flux's session scope). |
 | **Improve** | *On friction:* analyze sessions, recommend tools from the [recommendations engine](https://github.com/Nairon-AI/flux-recommendations). Auto-suggested on friction (score >= 3) and via session start pulse when new tools are available. |
 
 ---

--- a/skills/flux-prime/workflow.md
+++ b/skills/flux-prime/workflow.md
@@ -505,3 +505,26 @@ If yes, run Phase 1-4 again and show:
 ```
 
 Without this step, `session-state` will always report `needs_prime` and block the user from scoping or implementation.
+
+---
+
+## Phase 9: Auto-Ruminate (conditional)
+
+After marking prime complete, check if the brain vault is thin and past conversations exist. If so, auto-run `/flux:ruminate` to bootstrap the brain vault from conversation history.
+
+**Trigger conditions** (ALL must be true):
+1. Brain vault has fewer than 5 files in `brain/pitfalls/` and `brain/principles/`
+2. Past Claude Code conversations exist (`~/.claude/projects/` has session data for this project)
+3. This is the first prime for this project
+
+```bash
+BRAIN_FILES=$(find .flux/brain/pitfalls .flux/brain/principles -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
+PROJECT_PATH=$(pwd | sed 's|/|-|g')
+PAST_SESSIONS=$(ls ~/.claude/projects/*${PROJECT_PATH}*/*.jsonl 2>/dev/null | wc -l | tr -d ' ')
+```
+
+If `BRAIN_FILES < 5` and `PAST_SESSIONS > 0`, run `/flux:ruminate` automatically. Do not ask — just run it. Tell the user:
+
+```
+Brain vault is thin — mining past conversations to bootstrap knowledge...
+```

--- a/skills/flux-reflect/SKILL.md
+++ b/skills/flux-reflect/SKILL.md
@@ -131,3 +131,17 @@ Follow-up work that can't be done during reflection — bugs, non-trivial rewrit
 - Structural: [rules/scripts/checks added]
 - Todos: [follow-up items filed]
 ```
+
+## Auto-Meditate (conditional)
+
+After reflection is complete, check if the brain vault needs maintenance:
+
+```bash
+PITFALL_COUNT=$(find .flux/brain/pitfalls -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
+```
+
+If `PITFALL_COUNT >= 20`, automatically run `/flux:meditate` to prune stale content and promote recurring patterns to principles. Do not ask — just run it. Tell the user:
+
+```
+Brain vault has {PITFALL_COUNT} pitfalls — running meditate to prune and promote...
+```

--- a/skills/flux-work/phases.md
+++ b/skills/flux-work/phases.md
@@ -368,7 +368,7 @@ Ralph closes done epics at the end of the loop.
 
 Then push + open PR if user wants.
 
-**Suggest reflection**: After shipping, suggest the user run `/flux:reflect` to capture learnings from this epic while context is fresh. This feeds the brain vault's continuous improvement loop (reflect → ruminate → meditate).
+**Auto-reflect**: After submitting the PR, automatically run `/flux:reflect` to capture learnings while context is fresh. Do not ask — just run it. If the brain vault has 20+ pitfall files after reflection, also run `/flux:meditate` to prune and promote.
 
 ## Definition of Done
 


### PR DESCRIPTION
## Summary
- **Reflect** auto-triggers after Submit (PR created) — no longer just suggested
- **Meditate** auto-triggers after Reflect when brain has 20+ pitfall files
- **Ruminate** auto-triggers after Prime when brain is thin and past sessions exist
- Renamed **Ship → Submit** (PR created) to distinguish from actual shipping (PR merged/deployed)
- Architecture diagram and phase table updated

## Flow changes
```
Before: ... → Ship → "suggest /flux:reflect" → Done
After:  ... → Submit → Reflect → Meditate (if 20+ pitfalls) → Done

Before: ... → Prime → Scope
After:  ... → Prime → Ruminate (if brain thin) → Scope
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)