### PR TITLE
feat: detect infra providers during prime, recommend MCPs/CLIs

### DIFF
--- a/skills/flux-prime/SKILL.md
+++ b/skills/flux-prime/SKILL.md
@@ -27,8 +27,13 @@ Agents waste cycles when:
 - Undocumented env vars → guesses, fails, guesses again
 - No CLAUDE.md → doesn't know project conventions
 - Missing test commands → can't verify changes work
+- No provider CLIs/MCPs → user has to context-switch to Vercel/Railway/Neon dashboards for every deploy or DB query
 
 These are **environment problems**, not agent problems. Prime helps fix them.
+
+## Infrastructure Provider Detection
+
+Prime scans the codebase for cloud providers (Vercel, Railway, Neon, Supabase, Cloudflare, AWS, Stripe, etc.) and recommends MCPs or CLIs that give agents direct access. This means agents can deploy, query databases, check logs, and manage secrets without the user needing to open provider dashboards.
 
 ## Session Phase Tracking
 

--- a/skills/flux-prime/remediation.md
+++ b/skills/flux-prime/remediation.md
@@ -312,6 +312,53 @@ jobs:
 
 ---
 
+## Infrastructure MCPs & CLIs
+
+When the prime assessment detects infrastructure providers in the codebase, recommend the corresponding MCPs or CLIs. These let agents deploy, query databases, check logs, and manage infrastructure directly — without the user switching to provider dashboards.
+
+**Only recommend tools for providers actually detected in the codebase.** Never suggest tools for providers the project doesn't use.
+
+### Hosting & Deployment
+
+| Provider | Detection Signals | MCP/CLI | Install | What Agents Can Do |
+|----------|-------------------|---------|---------|-------------------|
+| **Vercel** | `vercel.json`, `@vercel/*` deps, `VERCEL_*` env | Vercel MCP | `npx @vercel/mcp@latest` (follow setup) | Manage deployments, check build logs, manage env vars, query analytics |
+| **Netlify** | `netlify.toml`, `NETLIFY_*` env | Netlify CLI | `npm i -g netlify-cli && netlify login` | Deploy, check build status, manage sites, view function logs |
+| **Railway** | `railway.json`, `railway.toml`, `RAILWAY_*` env | Railway CLI | `npm i -g @railway/cli && railway login` | Deploy, view logs, manage services, check deployments |
+| **Fly.io** | `fly.toml`, `FLY_*` env | Fly CLI | `brew install flyctl && fly auth login` | Deploy, scale, view logs, manage secrets |
+| **Render** | `render.yaml`, `RENDER_*` env | Render CLI | `brew install render` | Deploy, manage services, view logs |
+| **Cloudflare Workers** | `wrangler.toml`, `wrangler.jsonc`, `@cloudflare/workers-*` deps | Cloudflare MCP | `npx @anthropic-ai/mcp@latest cloudflare` (follow setup) | Deploy workers, manage KV/D1/R2, check analytics |
+| **AWS** | `@aws-sdk/*` deps, `AWS_*` env, `amplify.yml` | AWS MCP | `npx @anthropic-ai/mcp@latest aws` (follow setup) | Manage S3, Lambda, CloudFormation, view CloudWatch logs |
+
+### Databases
+
+| Provider | Detection Signals | MCP/CLI | Install | What Agents Can Do |
+|----------|-------------------|---------|---------|-------------------|
+| **Neon** | `@neondatabase/*` deps, `NEON_*` env, `DATABASE_URL.*neon` | Neon MCP | `npx @anthropic-ai/mcp@latest neon` (follow setup) | Create/manage databases, run SQL, manage branches |
+| **Supabase** | `supabase/` dir, `@supabase/*` deps, `SUPABASE_*` env | Supabase MCP | `npx @anthropic-ai/mcp@latest supabase` (follow setup) | Manage tables, run SQL, manage auth, check edge functions |
+| **PlanetScale** | `@planetscale/*` deps, `PLANETSCALE_*` env | PlanetScale CLI | `brew install planetscale/tap/pscale && pscale auth login` | Create branches, run schema changes, query databases |
+| **Turso** | `@libsql/*` deps, `TURSO_*` env | Turso CLI | `brew install tursodatabase/tap/turso && turso auth login` | Manage databases, create replicas, run SQL |
+| **Upstash** | `@upstash/*` deps, `UPSTASH_*` env | Upstash MCP | `npx @anthropic-ai/mcp@latest upstash` (follow setup) | Manage Redis/Kafka instances, check metrics |
+
+### Services & APIs
+
+| Provider | Detection Signals | MCP/CLI | Install | What Agents Can Do |
+|----------|-------------------|---------|---------|-------------------|
+| **Stripe** | `stripe` dep, `STRIPE_*` env | Stripe MCP | `npx @anthropic-ai/mcp@latest stripe` (follow setup) | Test webhooks, manage products, check payments, view logs |
+| **Resend** | `resend` dep, `RESEND_*` env | Resend MCP | Configure in Claude MCP settings | Send test emails, manage domains, check delivery status |
+| **Firebase** | `firebase.json`, `.firebaserc`, `firebase-admin` dep | Firebase CLI | `npm i -g firebase-tools && firebase login` | Deploy functions, manage Firestore, check hosting |
+| **Doppler** | `doppler.yaml`, `DOPPLER_*` env | Doppler CLI | `brew install dopplerhq/cli/doppler && doppler login` | Manage secrets across environments, sync env vars |
+
+### Installation Rules
+
+1. **MCP over CLI** — If both exist, prefer the MCP (richer integration with agents)
+2. **Auth required** — Most tools need authentication. Tell the user which ones need `login` after install
+3. **Verify install** — After each install, verify with `which <tool>` or the tool's `--version` flag
+4. **Don't auto-configure MCP settings** — MCPs that need Claude Desktop/Code config should tell the user what to add, not modify config files directly
+5. **Group if many** — If >4 providers detected, group into "Hosting", "Database", "Services" questions
+
+---
+
 ## Application Rules
 
 1. **Detect before creating** - Check if file exists first

--- a/skills/flux-prime/workflow.md
+++ b/skills/flux-prime/workflow.md
@@ -211,6 +211,38 @@ Calculate:
 
 **Overall Score** = average of all 8 pillar scores
 
+### Infrastructure Provider Detection
+
+Scan the codebase to identify cloud providers and services. This feeds the "Infrastructure MCPs & CLIs" question in Phase 5.
+
+```bash
+# 1. Config files — existence implies usage
+for f in vercel.json railway.json railway.toml netlify.toml fly.toml render.yaml wrangler.toml wrangler.jsonc amplify.yml firebase.json .firebaserc supabase/.temp/project-ref doppler.yaml; do
+  [ -f "$f" ] && echo "CONFIG: $f"
+done
+
+# 2. Dependencies — scan manifests
+for manifest in package.json apps/*/package.json packages/*/package.json requirements*.txt Pipfile pyproject.toml Cargo.toml go.mod; do
+  [ -f "$manifest" ] && grep -oE '@vercel/|@neondatabase/|@supabase/|@planetscale/|@cloudflare/workers|@aws-sdk/|@google-cloud/|firebase-admin|stripe|resend|@upstash/|@libsql/|@prisma/' "$manifest" 2>/dev/null | sort -u | sed "s/^/DEP ($manifest): /"
+done
+
+# 3. Environment variable prefixes — scan .env examples
+for envfile in .env.example .env.local.example .env.template; do
+  [ -f "$envfile" ] && grep -oE '^(VERCEL|RAILWAY|NEON|SUPABASE|PLANETSCALE|CLOUDFLARE|AWS|GOOGLE_CLOUD|FIREBASE|FLY|RENDER|NETLIFY|STRIPE|RESEND|UPSTASH|TURSO|DOPPLER)_' "$envfile" 2>/dev/null | sort -u | sed "s/^/ENV ($envfile): /"
+done
+```
+
+Build a list of detected providers. For each, check if the corresponding MCP or CLI is already installed:
+
+```bash
+# Check existing tooling (skip recommendations for already-installed tools)
+which vercel netlify railway flyctl render wrangler firebase pscale turso doppler stripe 2>/dev/null
+# Check MCP configs
+cat ~/.claude/settings.json 2>/dev/null | grep -o '"[^"]*mcp[^"]*"' | head -20
+```
+
+Only recommend MCPs/CLIs for providers that are detected AND whose tooling is NOT already installed.
+
 ### Prioritize Recommendations
 
 Generate prioritized recommendations from **Pillars 1-5 only**:
@@ -281,6 +313,14 @@ Informational only. No fixes offered — address independently if desired.
 ## Production Readiness Notes
 
 [Key observations from Pillars 6-8 that the team should be aware of]
+
+## Infrastructure Providers Detected
+
+| Provider | Signal | Agent Tooling | Status |
+|----------|--------|---------------|--------|
+| [Provider] | [config file / dep / env var] | [MCP/CLI name] | ✅ Installed / ❌ Not installed |
+
+[If no providers detected, omit this section entirely]
 ```
 
 **If `--report-only`**: Show report, then skip to Phase 8 (mark prime complete) and exit.
@@ -433,6 +473,49 @@ which agent-browser >/dev/null 2>&1 && echo "agent-browser installed successfull
 }
 ```
 
+**Question 6: Infrastructure MCPs & CLIs (if providers detected)**
+
+Scan the codebase for infrastructure providers and recommend MCPs or CLIs that let agents interact with them directly — without the user needing to context-switch to dashboards.
+
+**Detection**: Search for provider signals across the codebase:
+
+```bash
+# Config files
+ls vercel.json railway.json railway.toml netlify.toml fly.toml render.yaml supabase/.temp/project-ref wrangler.toml wrangler.jsonc amplify.yml firebase.json .firebaserc 2>/dev/null
+
+# Package dependencies (check package.json, requirements.txt, Cargo.toml, go.mod)
+# Look for: @vercel/*, @neondatabase/*, @supabase/*, @prisma/*, @planetscale/*, @cloudflare/workers-*, @aws-sdk/*, @google-cloud/*, firebase-admin, stripe, resend, @upstash/*
+
+# Environment variables
+grep -rh 'VERCEL\|RAILWAY\|NEON_\|SUPABASE\|DATABASE_URL.*neon\|DATABASE_URL.*supabase\|PLANETSCALE\|CLOUDFLARE\|AWS_\|GOOGLE_CLOUD\|FIREBASE\|FLY_\|RENDER_\|NETLIFY\|STRIPE_\|RESEND_\|UPSTASH_\|TURSO_\|DOPPLER_' .env.example .env.local.example *.env 2>/dev/null | head -20
+```
+
+**Provider → MCP/CLI catalog** (see [remediation.md](remediation.md#infrastructure-mcps--clis) for full catalog):
+
+Only include providers actually detected in the codebase. Build the options list dynamically from matches. Prioritize MCPs (richer agent integration) over bare CLIs.
+
+```json
+{
+  "questions": [{
+    "question": "I detected these infrastructure providers in your codebase. Installing their MCPs/CLIs lets agents manage deployments, query databases, and check logs without you switching to dashboards.",
+    "header": "Infra",
+    "multiSelect": true,
+    "options": [
+      {
+        "label": "Install [Provider] MCP (Recommended)",
+        "description": "[What it enables for agents]. Install: [command]"
+      },
+      {
+        "label": "Skip infrastructure tooling",
+        "description": "Set up provider CLIs/MCPs later"
+      }
+    ]
+  }]
+}
+```
+
+If items selected, install in Phase 6 using the commands from the catalog. Verify each install succeeds before moving to the next.
+
 ### Rules for Questions
 
 1. **MUST use AskUserQuestion tool** — Never just print questions
@@ -440,7 +523,7 @@ which agent-browser >/dev/null 2>&1 && echo "agent-browser installed successfull
 3. **Mark bonus items** — Add "(Bonus)" to nice-to-have options
 4. **Explain agent benefit** — Each description should say WHY it helps agents
 5. **Skip empty categories** — Don't ask if no recommendations
-6. **Max 4 options per question** — Tool limit, prioritize if more
+6. **Max 4 options per question** — Tool limit, prioritize if more. For infra, group by category (hosting, database, services) if >4 detected
 7. **Never offer Pillar 6-8 items** — Production readiness is informational only
 
 ---


### PR DESCRIPTION
## Summary

- During `/flux:prime`, scan the codebase for infrastructure providers (Vercel, Railway, Neon, Supabase, Cloudflare, AWS, Stripe, etc.)
- Detect via config files (`vercel.json`, `fly.toml`), dependencies (`@neondatabase/*`, `stripe`), and env var prefixes (`VERCEL_*`, `NEON_*`)
- Recommend MCPs or CLIs that let agents interact with detected infra directly — deploy, query databases, check logs, manage secrets
- **16 providers** cataloged across hosting (Vercel, Netlify, Railway, Fly, Render, Cloudflare, AWS), databases (Neon, Supabase, PlanetScale, Turso, Upstash), and services (Stripe, Resend, Firebase, Doppler)
- Checks if tooling is already installed before recommending
- MCPs preferred over bare CLIs (richer agent integration)

## Why

Agents shouldn't need users to context-switch to provider dashboards for every deploy or DB query. If the project uses Vercel and Neon, the agent should be able to `vercel deploy` and run SQL directly.

## Test plan

- [ ] Run `/flux:prime` on a project with `vercel.json` — should detect Vercel and offer MCP install
- [ ] Run on a project with `@neondatabase/serverless` in package.json — should detect Neon
- [ ] Run on a project with no providers — infra section should be omitted from report
- [ ] Already-installed tools should be skipped in recommendations

🤖 Generated with [Claude Code](https://claude.com/claude-code)