### PR TITLE
feat: allow same-provider model pairs for adversarial review

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ flowchart TD
     subgraph review_pipeline ["Epic Review Pipeline"]
         direction TB
         SpecCompliance["Spec Compliance"]
-        Adversarial["Adversarial Review<br/>(Anthropic + OpenAI)"]
+        Adversarial["Adversarial Review<br/>(Dual-Model Consensus)"]
         SecurityScan["STRIDE Security Scan"]
         BotSelfHeal["BYORB Self-Heal<br/>(Greptile / CodeRabbit)<br/><i>optional</i>"]
         BrowserQA["Browser QA"]
@@ -415,14 +415,14 @@ Full pipeline that runs once when all epic tasks are done:
 | Phase | What happens |
 |-------|-------------|
 | Spec compliance | Verify every requirement from the epic spec is implemented |
-| Adversarial review | Two models from different labs (Anthropic + OpenAI) review independently — consensus issues = high confidence |
+| Adversarial review | Two different models review independently — cross-lab pairs (Anthropic + OpenAI) are strongest but same-provider pairs work too. Consensus issues = high confidence |
 | Severity filtering | Only auto-fix issues at/above your configured threshold (critical, major, minor, style) |
 | Security scan | STRIDE-based vulnerability scan — auto-triggered when changes touch auth, API, secrets, or permissions |
 | BYORB self-heal | Bring Your Own Review Bot — Greptile or CodeRabbit catch what models miss |
 | Browser QA | Test acceptance criteria from scoping checklist via [agent-browser](https://github.com/AgnBc/agent-browser) |
 | Learning capture | Extract patterns from review feedback into `.flux/brain/pitfalls/` |
 
-> **Why adversarial?** A single model has blind spots. Two models from different labs (e.g., Claude + GPT) with different training data and biases catch issues that neither finds alone. When both models flag the same issue, it's almost certainly real. When only one does, Flux uses your severity threshold to decide whether to fix or log.
+> **Why adversarial?** A single model has blind spots. Two different models (e.g., Claude + GPT, or Opus + Sonnet) catch issues that neither finds alone. Cross-lab pairs are strongest since different training data eliminates shared biases, but same-provider pairs still add value. When both models flag the same issue, it's almost certainly real. When only one does, Flux uses your severity threshold to decide whether to fix or log.
 
 #### Security — Built Into the Review Pipeline
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -386,7 +386,7 @@ When `epic_review` is active, the review pipeline executes these steps in order:
 | Step | Name | Purpose |
 |------|------|---------|
 | 1 | Spec Compliance | Verify implementation matches epic spec |
-| 2 | Adversarial Review | Dual-model review (Anthropic + OpenAI) |
+| 2 | Adversarial Review | Dual-model review (cross-lab or same-provider) |
 | 3 | STRIDE Security Scan | Threat model analysis of changes |
 | 4 | BYORB Self-Heal | External bot review (Greptile/CodeRabbit) — **optional**, skipped if no bot configured |
 | 5 | Browser QA | Visual verification of UI changes — skipped if pure backend |

--- a/skills/flux-epic-review/SKILL.md
+++ b/skills/flux-epic-review/SKILL.md
@@ -8,7 +8,7 @@ user-invocable: false
 
 **Read [workflow.md](workflow.md) for detailed phases and anti-patterns.**
 
-Thorough review at epic completion. Combines adversarial dual-model review (Anthropic + OpenAI consensus), external bot self-heal (Greptile/CodeRabbit), browser QA, and learning capture. Per-task lightweight reviews happen via `/flux:impl-review` — this is the heavy-weight pass.
+Thorough review at epic completion. Combines adversarial dual-model review (two different models reach consensus), external bot self-heal (Greptile/CodeRabbit), browser QA, and learning capture. Cross-lab pairs (Anthropic + OpenAI) are strongest, but same-provider pairs work too. Per-task lightweight reviews happen via `/flux:impl-review` — this is the heavy-weight pass.
 
 **Role**: Epic Review Coordinator (NOT the reviewer)
 **Backends**: RepoPrompt (rp) or Codex CLI (codex)
@@ -134,8 +134,8 @@ REVIEW_BOT=$($FLUXCTL config get review.bot 2>/dev/null || echo "")
 SEVERITIES=$($FLUXCTL config get review.severities 2>/dev/null || echo "critical,major")
 ```
 
-- `REVIEWER1`: Anthropic model (e.g., `claude-sonnet-4-5-20250514`)
-- `REVIEWER2`: OpenAI model (e.g., `o3`)
+- `REVIEWER1`: First review model (e.g., `claude-sonnet-4-6`, `gpt-5.4`)
+- `REVIEWER2`: Second review model — must be different from REVIEWER1 (e.g., `gpt-5.3-codex`, `claude-opus-4-6`)
 - `REVIEW_BOT`: `greptile`, `coderabbit`, or empty
 - `SEVERITIES`: comma-separated list of severity levels to auto-fix (e.g., `critical,major`)
 
@@ -170,8 +170,8 @@ If only one reviewer or neither is configured, skip to Step 4.
 
 See [workflow.md](workflow.md) "Adversarial Review Phase" for full details. Summary:
 
-1. **Reviewer 1** (Anthropic) reviews the diff independently via Codex/RP
-2. **Reviewer 2** (OpenAI) reviews the same diff independently via Codex
+1. **Reviewer 1** reviews the diff independently via Codex/RP
+2. **Reviewer 2** reviews the same diff independently via Codex/RP
 3. **Consensus merge**: Issues flagged by BOTH reviewers = high-confidence (auto-fix). Issues flagged by only one = log-only (unless at/above severity threshold).
 
 The adversarial approach catches more issues than a single model while reducing false positives through consensus.

--- a/skills/flux-epic-review/workflow.md
+++ b/skills/flux-epic-review/workflow.md
@@ -4,7 +4,7 @@
 
 Epic completion review is the thorough review gate. It combines:
 - **Spec compliance** — verify all requirements are implemented (single-model, same as before)
-- **Adversarial review** — dual-model consensus (Anthropic + OpenAI) for high-confidence issue detection
+- **Adversarial review** — dual-model consensus (two different models) for high-confidence issue detection
 - **Severity filtering** — only auto-fix issues at/above configured threshold
 - **External bot self-heal** — Greptile/CodeRabbit catch what models miss
 - **Browser QA** — verify acceptance criteria in actual browser
@@ -356,7 +356,7 @@ If only one or neither is set, skip directly to External Bot Self-Heal Phase.
 
 ### Purpose
 
-Two models from different labs (Anthropic + OpenAI) review the same diff independently. Issues flagged by both = high-confidence consensus issues that almost certainly need fixing. Issues from only one model = lower confidence, filtered by severity threshold.
+Two different models review the same diff independently. Cross-lab pairs (Anthropic + OpenAI) are strongest since different training data eliminates shared blind spots, but same-provider pairs (e.g., two Claude models) also work well. Issues flagged by both = high-confidence consensus issues that almost certainly need fixing. Issues from only one model = lower confidence, filtered by severity threshold.
 
 ### Step 1: Prepare Adversarial Diff
 
@@ -444,7 +444,7 @@ ADVEOF
 
 **CRITICAL: Independent context.** Each reviewer must form its verdict independently. Do NOT share Reviewer 1's output with Reviewer 2 or vice versa. The consensus merge in Step 4 is where findings are compared — not before. Sharing outputs before independent review creates echo-chamber sycophancy where the second model defers to the first.
 
-**Reviewer 1** (Anthropic model via Codex or RP — uses same backend as spec review):
+**Reviewer 1** (via Codex or RP — uses same backend as spec review):
 ```bash
 # If using codex backend:
 $FLUXCTL codex adversarial-review "$EPIC_ID" --model "$REVIEWER1" --prompt-file /tmp/adversarial-prompt.md > /tmp/review1-response.txt
@@ -453,9 +453,13 @@ $FLUXCTL codex adversarial-review "$EPIC_ID" --model "$REVIEWER1" --prompt-file 
 $FLUXCTL rp chat-send --window "$W" --tab "$T" --message-file /tmp/adversarial-prompt.md --new-chat --chat-name "Adversarial R1: $EPIC_ID"
 ```
 
-**Reviewer 2** (OpenAI model via Codex):
+**Reviewer 2** (via Codex or RP):
 ```bash
+# If using codex backend:
 $FLUXCTL codex adversarial-review "$EPIC_ID" --model "$REVIEWER2" --prompt-file /tmp/adversarial-prompt.md > /tmp/review2-response.txt
+
+# If using rp backend, send via RP chat (new chat for adversarial):
+$FLUXCTL rp chat-send --window "$W" --tab "$T" --message-file /tmp/adversarial-prompt.md --new-chat --chat-name "Adversarial R2: $EPIC_ID"
 ```
 
 ### Step 4: Consensus Merge
@@ -1106,7 +1110,7 @@ By combining signals, the friction score distinguishes between "complex epic tha
 - **Direct codex calls** - Must use `fluxctl codex` wrappers
 
 **Adversarial review:**
-- **Using same lab for both models** - Must be different labs (Anthropic + OpenAI)
+- **Using the exact same model for both reviewers** - Must be two different models (cross-lab is best, but same-provider with different models works too)
 - **Skipping consensus merge** - Both responses must be parsed and merged
 - **Auto-fixing single-model minor issues** - Only consensus or above-threshold
 

--- a/skills/flux-setup/workflow.md
+++ b/skills/flux-setup/workflow.md
@@ -1455,32 +1455,67 @@ Save to config:
 **Adversarial Reviewer 1 question** (include if review backend is NOT "None"):
 ```json
 {
-  "header": "Adversarial Reviewer 1 (Anthropic)",
-  "question": "Pick the first reviewer model. Flux uses two models from different labs to reach consensus — issues both agree on get fixed automatically.",
+  "header": "Adversarial Reviewer 1",
+  "question": "Pick the first reviewer model. Flux uses two models to reach consensus — issues both agree on get fixed automatically.\n\n💡 Cross-lab reviews (Anthropic + OpenAI) are strongest — different training eliminates shared blind spots. But same-provider pairs work too if you don't have a Codex subscription.",
   "options": [
-    {"label": "claude-opus-4-6", "description": "Most capable. Best for complex architecture reviews."},
-    {"label": "claude-sonnet-4-6", "description": "Fast and capable. Good balance of speed and depth."},
-    {"label": "claude-haiku-4-5", "description": "Fastest. Good for quick reviews on smaller changes."},
-    {"label": "claude-sonnet-4-5", "description": "Previous generation Sonnet. Solid reviewer."}
+    {"label": "claude-opus-4-6", "description": "Anthropic. Most capable. Best for complex architecture reviews."},
+    {"label": "claude-sonnet-4-6", "description": "Anthropic. Fast and capable. Good balance of speed and depth."},
+    {"label": "claude-haiku-4-5", "description": "Anthropic. Fastest. Good for quick reviews on smaller changes."},
+    {"label": "claude-sonnet-4-5", "description": "Anthropic. Previous generation Sonnet. Solid reviewer."},
+    {"label": "gpt-5.4", "description": "OpenAI. Most capable OpenAI model. Requires ChatGPT Plus or higher."},
+    {"label": "gpt-5.3-codex", "description": "OpenAI. Balanced model. Requires ChatGPT Plus or higher."},
+    {"label": "gpt-5.3-codex-spark", "description": "OpenAI. Fastest model. Requires ChatGPT Pro."},
+    {"label": "o4-mini", "description": "OpenAI. Reasoning model. Requires ChatGPT Plus or higher."}
   ],
   "multiSelect": false
 }
 ```
 
 **Adversarial Reviewer 2 question** (include if review backend is NOT "None"):
+
+First, determine what provider the user picked for Reviewer 1:
+- Anthropic models: `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5`, `claude-sonnet-4-5`
+- OpenAI models: `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `o4-mini`
+
+If Reviewer 1 is an Anthropic model, show the recommendation nudge for cross-lab (OpenAI) but still offer all models:
 ```json
 {
-  "header": "Adversarial Reviewer 2 (OpenAI)",
-  "question": "Pick the second reviewer model from a different lab. Cross-lab consensus eliminates single-model blind spots.",
+  "header": "Adversarial Reviewer 2",
+  "question": "Pick the second reviewer model.\n\n⭐ Recommended: Pick an OpenAI model for cross-lab consensus — the $20/mo ChatGPT Plus plan unlocks gpt-5.4 and o4-mini via Codex, and the reviews will be far superior to same-provider pairs.\n\nBut if you don't have or want a Codex subscription, picking a different Anthropic model still works.",
   "options": [
-    {"label": "gpt-5.4", "description": "Most capable OpenAI model. Requires ChatGPT Plus or higher."},
-    {"label": "gpt-5.3-codex", "description": "Balanced OpenAI model. Requires ChatGPT Plus or higher."},
-    {"label": "gpt-5.3-codex-spark", "description": "Fastest OpenAI model. Requires ChatGPT Pro."},
-    {"label": "o4-mini", "description": "Reasoning model. Requires ChatGPT Plus or higher."}
+    {"label": "gpt-5.4", "description": "⭐ OpenAI. Most capable. Best cross-lab pairing. Requires ChatGPT Plus or higher."},
+    {"label": "gpt-5.3-codex", "description": "⭐ OpenAI. Balanced model. Requires ChatGPT Plus or higher."},
+    {"label": "gpt-5.3-codex-spark", "description": "⭐ OpenAI. Fastest model. Requires ChatGPT Pro."},
+    {"label": "o4-mini", "description": "⭐ OpenAI. Reasoning model. Requires ChatGPT Plus or higher."},
+    {"label": "claude-opus-4-6", "description": "Anthropic. Most capable. Same-provider pair — still useful."},
+    {"label": "claude-sonnet-4-6", "description": "Anthropic. Fast and capable. Same-provider pair."},
+    {"label": "claude-haiku-4-5", "description": "Anthropic. Fastest. Same-provider pair."},
+    {"label": "claude-sonnet-4-5", "description": "Anthropic. Previous generation. Same-provider pair."}
   ],
   "multiSelect": false
 }
 ```
+
+If Reviewer 1 is an OpenAI model, show the recommendation nudge for cross-lab (Anthropic) but still offer all models:
+```json
+{
+  "header": "Adversarial Reviewer 2",
+  "question": "Pick the second reviewer model.\n\n⭐ Recommended: Pick an Anthropic model for cross-lab consensus — different training data eliminates shared blind spots.\n\nBut if you prefer, picking a different OpenAI model still works.",
+  "options": [
+    {"label": "claude-opus-4-6", "description": "⭐ Anthropic. Most capable. Best cross-lab pairing."},
+    {"label": "claude-sonnet-4-6", "description": "⭐ Anthropic. Fast and capable. Good cross-lab pairing."},
+    {"label": "claude-haiku-4-5", "description": "⭐ Anthropic. Fastest. Good cross-lab pairing."},
+    {"label": "claude-sonnet-4-5", "description": "⭐ Anthropic. Previous generation. Solid cross-lab pairing."},
+    {"label": "gpt-5.4", "description": "OpenAI. Most capable. Same-provider pair — still useful."},
+    {"label": "gpt-5.3-codex", "description": "OpenAI. Balanced model. Same-provider pair."},
+    {"label": "gpt-5.3-codex-spark", "description": "OpenAI. Fastest model. Same-provider pair."},
+    {"label": "o4-mini", "description": "OpenAI. Reasoning model. Same-provider pair."}
+  ],
+  "multiSelect": false
+}
+```
+
+**Important**: The user MUST pick a different model for Reviewer 2 than Reviewer 1. If they pick the same model, show a warning: "Both reviewers are the same model — adversarial review needs two different models to produce meaningful consensus. Please pick a different model." and re-ask the Reviewer 2 question.
 
 **Code Review Bot question** (include if review backend is NOT "None"):
 ```json
@@ -1636,8 +1671,8 @@ esac
 
 **Adversarial Reviewers** (if questions were asked):
 ```bash
-"${PLUGIN_ROOT}/scripts/fluxctl" config set review.reviewer1 "<chosen_anthropic_model>" --json
-"${PLUGIN_ROOT}/scripts/fluxctl" config set review.reviewer2 "<chosen_openai_model>" --json
+"${PLUGIN_ROOT}/scripts/fluxctl" config set review.reviewer1 "<chosen_model_1>" --json
+"${PLUGIN_ROOT}/scripts/fluxctl" config set review.reviewer2 "<chosen_model_2>" --json
 ```
 
 **Code Review Bot** (if question was asked):
@@ -1734,7 +1769,7 @@ For each chosen file (CLAUDE.md and/or AGENTS.md):
 
 ## Step 7b: Codex Verification (conditional)
 
-**Only run this step if the user chose a Codex/OpenAI model for either scouts or reviews** (i.e. scout model starts with `gpt-`/`o1`/`o3`/`o4`, or review backend is `codex`).
+**Only run this step if the user chose a Codex/OpenAI model for scouts, reviews, or adversarial reviewers** (i.e. scout model starts with `gpt-`/`o1`/`o3`/`o4`, review backend is `codex`, or either reviewer1/reviewer2 starts with `gpt-`/`o1`/`o3`/`o4`).
 
 ### 1. Check Codex CLI is installed
 
@@ -1903,8 +1938,8 @@ Configuration (use fluxctl config set to change):
 - GitHub scout: <enabled|disabled>
 - Scout model: <claude-haiku-4-5|gpt-5.3-codex-spark>
 - Review backend: <codex|rp|none>
-- Adversarial reviewer 1: <model> (Anthropic)
-- Adversarial reviewer 2: <model> (OpenAI)
+- Adversarial reviewer 1: <model>
+- Adversarial reviewer 2: <model>
 - Code review bot: <greptile|coderabbit|none>
 - Review severities: <critical,major,minor,style>
 - PR template: <created|skipped|already exists>


### PR DESCRIPTION
## What this PR does

Removes the forced Anthropic/OpenAI provider split for adversarial review. Users can now pick any two different models from either provider (e.g. Opus + Sonnet for Claude-only setups). The setup wizard dynamically recommends cross-lab pairs and nudges the $20/mo ChatGPT Plus plan for superior reviews, but no longer blocks same-provider selection.

**Files changed:**
- `skills/flux-setup/workflow.md` — Reviewer 1 shows all 8 models; Reviewer 2 dynamically reorders based on Reviewer 1's provider with cross-lab starred. Added same-model validation. Updated Codex verification trigger and summary template.
- `skills/flux-epic-review/SKILL.md` + `workflow.md` — Removed hardcoded provider labels, Reviewer 2 can now use RP backend, anti-pattern updated from "different labs" to "different models".
- `README.md` + `docs/state-machine.md` — Updated diagram labels and descriptions to be provider-agnostic.

## Conversation History

<!-- 
REQUIRED: Link to your exported AI conversation(s) that helped you build this.
Upload to gist.github.com, paste.gg, or include inline.
-->

## Demo Video

<!-- 
REQUIRED: Link to a video/gif showing your change working.
Loom, YouTube (unlisted), or gif all work.
-->

## Social Post

<!-- 
REQUIRED: Link to your social media post about this contribution.
Twitter/X, LinkedIn, Bluesky, or Threads. Tag @naaboromern.
-->

## Checklist

- [ ] I used Flux to build this (`/flux:scope`, `/flux:work`, etc.)
- [ ] I exported and linked my conversation history above
- [ ] I included a demo video above
- [ ] I posted to social media and linked it above
- [ ] I've read the [CONTRIBUTING.md](https://github.com/Nairon-AI/flux/blob/main/CONTRIBUTING.md)

---

> PRs missing any of these requirements will be automatically closed after 48 hours.