### PR TITLE
docs: update OpenCode port parity from ~45% to ~80%

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Ship with confidence. Sleep better at night.
 | Agent | Status | Install |
 |-------|--------|---------|
 | [Claude Code](https://claude.ai/code) | ✅ First-Class Support | `/plugin add https://github.com/Nairon-AI/flux@latest` |
-| [OpenCode](https://github.com/anomalyco/opencode) | `[█████░░░░░░] ~45%` | [flux-opencode](https://github.com/Nairon-AI/flux-opencode) — core workflow ported, v2.0+ features pending |
+| [OpenCode](https://github.com/anomalyco/opencode) | `[████████░░░] ~80%` | [flux-opencode](https://github.com/Nairon-AI/flux-opencode) — brain vault, security suite, RCA, propose, gate ported |
 
 **Install** — say this in Claude Code:
 ```


### PR DESCRIPTION
## Summary

- Updates the OpenCode progress bar in the Install table from `~45%` to `~80%`
- Updates the description to reflect newly ported features: brain vault, security suite, RCA, propose, gate

This reflects the work in [flux-opencode#2](https://github.com/Nairon-AI/flux-opencode/pull/2) which ports 15 new skills, 18 commands, 3 hooks, and full install infrastructure.

## Test plan

- [x] Verify progress bar renders correctly in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)