### PR TITLE
feat: integrate expect.dev as diff-driven browser QA tool

### DIFF
--- a/skills/flux-epic-review/workflow.md
+++ b/skills/flux-epic-review/workflow.md
@@ -653,30 +653,56 @@ If CodeRabbit flagged issues:
 
 ## Browser QA Phase
 
-**Only runs if ALL of these are true:**
-1. `agent-browser` is available: `command -v agent-browser >/dev/null 2>&1`
-2. A "Browser QA Checklist" task exists for this epic (created during `/flux:scope`)
+**Two strategies available — agent-browser (checklist-driven) or expect-cli (diff-driven):**
 
-During scoping, Flux auto-creates a Browser QA Checklist task for epics involving frontend/web changes. This task contains structured, testable criteria that this phase follows — no guesswork needed.
+| Strategy | Requires | Best for |
+|---|---|---|
+| **agent-browser** | `agent-browser` CLI + Browser QA Checklist task | Structured acceptance criteria from `/flux:scope` |
+| **expect-cli** | `npx expect-cli` (zero install) | Auto-generated test plans from git diff — works without a checklist |
 
-### Step 1: Check Prerequisites
+During scoping, Flux auto-creates a Browser QA Checklist task for epics involving frontend/web changes. When that checklist exists and agent-browser is available, use agent-browser. Otherwise, fall back to expect-cli.
+
+### Step 1: Select Strategy
 
 ```bash
-if ! command -v agent-browser >/dev/null 2>&1; then
-  echo "agent-browser not found. Skipping browser QA."
-  # Skip to Learning Capture
+HAS_AGENT_BROWSER=false
+HAS_EXPECT=true  # always available via npx expect-cli
+QA_TASK=""
+
+if command -v agent-browser >/dev/null 2>&1; then
+  HAS_AGENT_BROWSER=true
 fi
+
+# Read user preference from config (set during /flux:setup)
+QA_PREF=$($FLUXCTL config get browserQa.tool --json 2>/dev/null | jq -r '.value // empty')
 
 # Look for Browser QA Checklist task in this epic
 QA_TASK=$($FLUXCTL tasks --epic "$EPIC_ID" --json | jq -r '.[] | select(.title | test("Browser QA|browser.qa"; "i")) | .id' | head -1)
 
-if [[ -z "$QA_TASK" ]]; then
-  echo "No Browser QA Checklist task found for $EPIC_ID. Skipping browser QA."
-  # Skip to Learning Capture
+# Strategy selection:
+# 1. If user explicitly configured "expect" → use expect
+# 2. If user configured "agent-browser" AND it's installed AND checklist exists → use agent-browser
+# 3. If agent-browser is available AND checklist exists (no config) → use agent-browser
+# 4. Fallback → expect-cli (always available via npx)
+if [[ "$QA_PREF" == "expect" ]]; then
+  QA_STRATEGY="expect"
+  echo "Browser QA: expect-cli (configured preference)"
+elif [[ "$HAS_AGENT_BROWSER" == "true" && -n "$QA_TASK" ]]; then
+  QA_STRATEGY="agent-browser"
+  echo "Browser QA: agent-browser with checklist ($QA_TASK)"
+else
+  QA_STRATEGY="expect"
+  echo "Browser QA: expect-cli (diff-driven fallback)"
 fi
 ```
 
-### Step 2: Read QA Checklist
+---
+
+### Strategy A: agent-browser (checklist-driven)
+
+**Used when:** `QA_STRATEGY="agent-browser"`
+
+#### A1: Read QA Checklist
 
 ```bash
 # Get the QA task spec with acceptance criteria
@@ -693,7 +719,7 @@ The checklist task contains structured acceptance criteria like:
 
 Each criterion specifies: URL/action, expected result, and what to verify.
 
-### Step 3: Execute Browser Tests
+#### A2: Execute Browser Tests
 
 For each criterion in the checklist:
 
@@ -716,7 +742,7 @@ agent-browser snapshot -i  # Re-snapshot after action
 agent-browser screenshot "/tmp/qa-${EPIC_ID}-${n}.png"
 ```
 
-### Step 4: Handle Failures
+#### A3: Handle Failures
 
 If any criterion fails:
 
@@ -727,13 +753,54 @@ If any criterion fails:
 5. Re-test the failing criterion
 6. Max 2 fix iterations per criterion
 
-### Step 5: Mark QA Task Complete
+#### A4: Mark QA Task Complete
 
 After all criteria pass:
 
 ```bash
 $FLUXCTL done "$QA_TASK"
 agent-browser close
+```
+
+---
+
+### Strategy B: expect-cli (diff-driven)
+
+**Used when:** `QA_STRATEGY="expect"` — no checklist or agent-browser needed.
+
+expect-cli (https://www.expect.dev) analyzes uncommitted git changes, AI-generates a test strategy, and runs it in a real browser with pass/fail results and recordings.
+
+#### B1: Run expect-cli
+
+```bash
+# expect-cli analyzes the git diff and generates + executes browser tests
+npx expect-cli
+```
+
+expect-cli will:
+1. Analyze uncommitted git changes (or branch diff)
+2. AI-generate a test strategy with specific verification steps
+3. Present the test plan in an interactive terminal for review
+4. Execute the test plan against a live browser
+5. Report pass/fail results with recordings
+
+#### B2: Handle Failures
+
+If any test fails:
+
+1. Review the failure output and recording from expect-cli
+2. Fix the code to address the issue
+3. Run tests/lints
+4. Commit: `git commit -m "fix: address expect-cli browser QA failure - <summary>"`
+5. Re-run: `npx expect-cli`
+6. Max 2 fix iterations
+
+#### B3: Mark QA Task (if exists)
+
+```bash
+if [[ -n "$QA_TASK" ]]; then
+  $FLUXCTL done "$QA_TASK"
+fi
 ```
 
 ---

--- a/skills/flux-gate/SKILL.md
+++ b/skills/flux-gate/SKILL.md
@@ -89,7 +89,8 @@ Ask the user how they want to validate staging:
 Staging is live. How do you want to validate?
 
 1. Agent Browser — automated browser QA against {STAGING_URL}
-2. Manual review — I'll show you what to check, you test and report back
+2. Expect — AI-generated test plan from git diff, runs in real browser
+3. Manual review — I'll show you what to check, you test and report back
 ```
 
 Use `AskUserQuestion` for this.
@@ -101,7 +102,7 @@ Check if agent-browser is available:
 command -v agent-browser >/dev/null 2>&1 && echo "available" || echo "not found"
 ```
 
-If not available, tell the user and fall back to manual review (Step 4b).
+If not available, tell the user and fall back to expect-cli (Step 4c) or manual review (Step 4b).
 
 If available, look for the Browser QA checklist from the most recently completed epic:
 ```bash
@@ -145,6 +146,29 @@ Report back with what you found — "all good" or describe any issues.
 ```
 
 Wait for the user's response. If issues reported, same options as 4a failures.
+
+### Step 4c: Expect CLI (if chosen)
+
+expect-cli (https://www.expect.dev) analyzes git changes, AI-generates a test strategy, and runs it in a real browser.
+
+```bash
+# Run expect-cli — it auto-detects changes and generates browser tests
+npx expect-cli
+```
+
+expect-cli will:
+1. Analyze the git diff (commits merged to staging vs production)
+2. AI-generate a test strategy with verification steps
+3. Present the plan for interactive review
+4. Execute tests in a real browser
+5. Report pass/fail with recordings
+
+After testing, report results:
+- **All pass**: Continue to Step 5
+- **Failures found**: List what failed, ask user if they want to:
+  1. Create fix tasks and address issues (new PR to staging)
+  2. Proceed anyway (user accepts the issues)
+  3. Abort promotion
 
 ### Step 5: Run e2e tests against staging (if available)
 

--- a/skills/flux-setup/SKILL.md
+++ b/skills/flux-setup/SKILL.md
@@ -23,7 +23,8 @@ Install fluxctl locally and add instructions to project docs. **Fully optional**
   - **jq** — JSON parsing for scripts and API output
   - **fzf** — fuzzy finder for terminal workflows
   - **Lefthook** — fast pre-commit hooks
-  - **Agent Browser** — browser automation CLI for agent-driven UI QA
+  - **Agent Browser** — checklist-driven browser QA with snapshots and screenshots
+  - **Expect** — diff-driven browser QA, AI generates test plans from git changes
   - **CLI Continues** — resume/switch session context across agent CLIs
 - **Optional** recommended desktop apps (OS-aware prompts in setup):
   - **Superset** — primary orchestrator for parallel Claude Code sessions using git worktrees

--- a/skills/flux-setup/workflow.md
+++ b/skills/flux-setup/workflow.md
@@ -653,7 +653,8 @@ Flux recommends CLI tools that complement the AI development workflow.
 | `jq` | jq | **JSON plumbing for agent scripts** — parse API/config output quickly | Yes | `brew install jq` | `sudo apt install jq` | `winget install --id jqlang.jq` |
 | `fzf` | fzf | **Fuzzy finder for shell + git navigation** — faster local workflows | Yes | `brew install fzf` | `sudo apt install fzf` | `winget install --id junegunn.fzf` |
 | `lefthook` | Lefthook | **Fast pre-commit hooks** — catch issues before CI | Yes | `npm i -g lefthook` | `npm i -g lefthook` | `npm i -g lefthook` |
-| `agent-browser` | Agent Browser | **Browser automation for coding agents** — UI QA and reproducible evidence | Yes | `npm i -g agent-browser` | `npm i -g agent-browser` | `npm i -g agent-browser` |
+| `agent-browser` | Agent Browser | **Checklist-driven browser QA** — step-by-step UI automation with snapshots and screenshots | Yes | `npm i -g agent-browser` | `npm i -g agent-browser` | `npm i -g agent-browser` |
+| `expect-cli` | Expect | **Diff-driven browser QA** — AI generates test plans from git changes and runs them in a real browser | Yes | `npm i -g expect-cli` | `npm i -g expect-cli` | `npm i -g expect-cli` |
 | `cli-continues` | CLI Continues | **Session handoff between agents** — resume context across tools | Yes | `npm i -g continues` | `npm i -g continues` | `npm i -g continues` |
 ### Detect existing tools
 
@@ -664,6 +665,7 @@ HAVE_JQ_CLI=$(which jq >/dev/null 2>&1 && echo 1 || echo 0)
 HAVE_FZF_CLI=$(which fzf >/dev/null 2>&1 && echo 1 || echo 0)
 HAVE_LEFTHOOK_CLI=$(which lefthook >/dev/null 2>&1 && echo 1 || echo 0)
 HAVE_AGENT_BROWSER_CLI=$(which agent-browser >/dev/null 2>&1 && echo 1 || echo 0)
+HAVE_EXPECT_CLI=$(which expect-cli >/dev/null 2>&1 && echo 1 || echo 0)
 HAVE_CONTINUES_CLI=$( (which continues >/dev/null 2>&1 || which cont >/dev/null 2>&1) && echo 1 || echo 0)
 HAVE_NPM=$(which npm >/dev/null 2>&1 && echo 1 || echo 0)
 HAVE_WINGET=$(which winget >/dev/null 2>&1 && echo 1 || echo 0)
@@ -701,6 +703,7 @@ INSTALL_JQ=0
 INSTALL_FZF=0
 INSTALL_LEFTHOOK=0
 INSTALL_AGENT_BROWSER=0
+INSTALL_EXPECT_CLI=0
 INSTALL_CONTINUES=0
 
 # Set each to 1 if selected by user
@@ -712,7 +715,8 @@ INSTALL_CONTINUES=0
 {"label": "jq", "description": "JSON parsing for scripts and API output (free)"}
 {"label": "fzf", "description": "Fuzzy finder for terminal, history, and git navigation (free)"}
 {"label": "Lefthook", "description": "Fast pre-commit hooks to catch issues before CI (free)"}
-{"label": "Agent Browser", "description": "Headless browser automation CLI for agent-driven QA (free)"}
+{"label": "Agent Browser", "description": "Checklist-driven browser QA — step-by-step automation with snapshots and screenshots (free)"}
+{"label": "Expect", "description": "Diff-driven browser QA — AI generates test plans from git changes, runs in real browser (free)"}
 {"label": "CLI Continues", "description": "Resume/switch coding session context across agent CLIs (free)"}
 ```
 
@@ -821,16 +825,64 @@ if [ "$INSTALL_FZF" = "1" ]; then
 fi
 ```
 
-**Lefthook / Agent Browser / CLI Continues (Node-based):**
+**Lefthook / Agent Browser / Expect / CLI Continues (Node-based):**
 ```bash
 if which npm >/dev/null 2>&1; then
   [ "$INSTALL_LEFTHOOK" = "1" ] && npm i -g lefthook 2>/dev/null || true
   [ "$INSTALL_AGENT_BROWSER" = "1" ] && npm i -g agent-browser 2>/dev/null || true
+  [ "$INSTALL_EXPECT_CLI" = "1" ] && npm i -g expect-cli 2>/dev/null || true
   [ "$INSTALL_CONTINUES" = "1" ] && npm i -g continues 2>/dev/null || true
 else
   echo "npm not found. Install Node.js first: https://nodejs.org"
 fi
 ```
+
+### Browser QA preference
+
+If the user installed **both** Agent Browser and Expect, or if both were already installed, ask which to use as the **primary** browser QA tool. This preference is used by `/flux:epic-review` and `/flux:gate` to select the default strategy.
+
+```bash
+# Check what's available after installation
+HAS_AB=$(which agent-browser >/dev/null 2>&1 && echo 1 || echo 0)
+HAS_EX=$(which expect-cli >/dev/null 2>&1 && echo 1 || echo 0)
+
+if [ "$HAS_AB" = "1" ] && [ "$HAS_EX" = "1" ]; then
+  # Both available — ask preference
+  # Present as AskUserQuestion:
+fi
+```
+
+**Question (only if both are available):**
+```
+You have two browser QA tools installed. Which should Flux use by default?
+
+1. **Agent Browser** — Checklist-driven. Follows structured acceptance criteria step-by-step
+   with snapshots and screenshots. Best when you have a Browser QA Checklist from /flux:scope.
+   Gives you fine-grained control over each verification step.
+
+2. **Expect** — Diff-driven. AI analyzes your git changes and auto-generates a test plan,
+   then runs it in a real browser. Best when you don't have a checklist or want zero-config
+   browser QA. Shows pass/fail with recordings.
+
+(The other tool is still available as a fallback)
+```
+
+**Store preference:**
+```bash
+# $QA_TOOL_PREF is "agent-browser" or "expect"
+$FLUXCTL config set browserQa.tool "$QA_TOOL_PREF"
+```
+
+**If only one is installed**, set it automatically without asking:
+```bash
+if [ "$HAS_AB" = "1" ] && [ "$HAS_EX" = "0" ]; then
+  $FLUXCTL config set browserQa.tool "agent-browser"
+elif [ "$HAS_AB" = "0" ] && [ "$HAS_EX" = "1" ]; then
+  $FLUXCTL config set browserQa.tool "expect"
+fi
+```
+
+**If neither is installed**, skip — expect-cli is always available via `npx expect-cli` as a zero-install fallback.
 
 ### Track installation results
 
@@ -1207,7 +1259,7 @@ Read current `.flux/meta.json`, add/update these fields (preserve all others):
     "mcp_servers": ["<list of MCP server names installed this session, e.g. fff, context7, exa, github, firecrawl>"],
     "skills": ["<list of skill names installed this session, e.g. ui-skills, taste-skill, agent-skills-vercel>"],
     "desktop_apps": ["<list of desktop apps installed this session, e.g. raycast, superset, wispr-flow, granola>"],
-    "cli_tools": ["<list of CLI tools installed this session, e.g. gh, jq, fzf, lefthook, agent-browser, cli-continues>"],
+    "cli_tools": ["<list of CLI tools installed this session, e.g. gh, jq, fzf, lefthook, agent-browser, expect-cli, cli-continues>"],
     "infra_cli": ["<platform CLI installed this session, e.g. vercel, railway, aws>"]
   }
 }
@@ -2001,7 +2053,9 @@ CLI tools:
 - fzf: <installed | already installed | skipped>
 - Lefthook: <installed | already installed | skipped>
 - Agent Browser: <installed | already installed | skipped>
+- Expect: <installed | already installed | skipped>
 - CLI Continues: <installed | already installed | skipped>
+- Browser QA preference: <agent-browser | expect | not set>
 ```
 
 Use tracking variables from Step 4d. If gh was already installed before setup, show "already installed".

--- a/skills/flux-work/phases.md
+++ b/skills/flux-work/phases.md
@@ -378,6 +378,7 @@ After all tasks complete (or periodically for large epics):
 - If change is large/risky, run the quality auditor subagent:
   - Task flux:quality-auditor("Review recent changes")
 - Fix critical issues
+- **Browser verification (web-facing changes):** If the epic touches frontend/UI code, run `npx expect-cli` to auto-generate and execute browser tests from the git diff. This catches visual regressions and interaction bugs that unit tests miss. expect-cli requires no setup — it analyzes uncommitted changes and runs an AI-generated test plan in a real browser.
 
 ## Phase 5: Ship
 


### PR DESCRIPTION
## Summary

- Adds [expect-cli](https://www.expect.dev) (`npx expect-cli`) as an alternative to `agent-browser` for browser QA across the Flux workflow
- expect-cli analyzes git changes, AI-generates a test strategy, and runs it in a real browser — works **without a pre-written QA checklist**
- Browser QA phase no longer gets skipped when a checklist is missing

## Changes

### `flux-epic-review` — Browser QA phase
- Two strategies: **agent-browser** (checklist-driven) and **expect-cli** (diff-driven)
- Reads `browserQa.tool` config preference (set during `/flux:setup`)
- Falls back to expect-cli when agent-browser or checklist is unavailable

### `flux-gate` — Staging validation
- Added expect-cli as a third option alongside agent-browser and manual review

### `flux-work` — Phase 4 Quality
- Added expect-cli browser verification step for web-facing changes

### `flux-setup` — CLI tools & preference
- Added expect-cli to CLI tools table with detection + installation
- New **Browser QA preference question** when both tools are available — explains benefits of each, stores choice in `browserQa.tool` config key
- Updated summary output to show expect-cli status and preference

## Test plan

- [ ] Run `/flux:setup` — verify expect-cli appears in CLI tools and preference question shows when both tools available
- [ ] Run `/flux:epic-review` without agent-browser — verify it falls back to expect-cli instead of skipping
- [ ] Run `/flux:gate` — verify "Expect" appears as option 2 in validation method choice
- [ ] Verify `browserQa.tool` config key is respected by epic-review strategy selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)