### PR TITLE
feat: smarter /flux:upgrade with changelog summary and setup guidance

### DIFF
--- a/commands/flux/upgrade.md
+++ b/commands/flux/upgrade.md
@@ -5,6 +5,8 @@ description: Upgrade Flux plugin and optionally update project setup
 
 # Flux Upgrade
 
+Upgrades the Flux plugin, shows the user what changed since their version, and tells them exactly what to do next.
+
 ## Step 1: Check current versions
 
 Run the version check to see where things stand:
@@ -13,46 +15,125 @@ Run the version check to see where things stand:
 bash "${CLAUDE_PLUGIN_ROOT:-${DROID_PLUGIN_ROOT:-$(dirname "$(dirname "$(dirname "$0")")")}}/scripts/version-check.sh"
 ```
 
-Parse the JSON output. Report to the user:
-- Local version: `local_version`
-- Remote version: `remote_version`
-- Update available: `update_available`
+Parse the JSON output. Save `local_version` as `OLD_VERSION` — you'll need it later.
 
-If no update is available, tell the user they're on the latest version.
+Report to the user:
+- Current version: `local_version`
+- Latest version: `remote_version`
 
-## Step 2: Ask scope
+If no update is available, tell the user they're on the latest version and stop.
 
-Use `AskUserQuestion`:
+## Step 2: Upgrade the plugin
 
-**"How do you want to upgrade?"**
-- "This project only" → upgrade plugin + re-run setup on current project
-- "All Flux projects on this machine" → upgrade plugin + scan and update all projects
-- "Plugin only (no project changes)" → just update the plugin, skip setup
+Follow the SKILL.md workflow Steps 2-5 to refresh marketplace metadata, clear plugin cache, and update the install record. This is the mechanical upgrade.
 
-## Step 3: Upgrade the plugin
+If any step fails, report the specific error and stop. Do not continue with a partial upgrade.
+
+## Step 3: Fetch what changed
+
+This step is what makes the upgrade informative. Get release notes for every version between `OLD_VERSION` and the new version.
+
+**Primary source — GitHub releases:**
 
 ```bash
-/plugin add https://github.com/Nairon-AI/flux@latest
+gh release list --repo Nairon-AI/flux --limit 30 --json tagName,name,body,publishedAt 2>/dev/null
 ```
 
-Tell the user:
-> Plugin upgraded. You'll need to restart with `--resume` for the new plugin to take effect.
-> After restarting, run `/flux:setup` to update this project's local files.
+Filter to releases where the tag version is greater than `OLD_VERSION` and less than or equal to the new version.
 
-If the user chose **"Plugin only"**, stop here.
-
-## Step 4: Re-run project setup
-
-If the user chose **"This project only"**:
-- Run `/flux:setup` which handles the upgrade path via `setup_version` comparison in `.flux/meta.json`
-- This is idempotent — it merges new config keys, copies updated skills, and refreshes CLAUDE.md markers
-
-If the user chose **"All Flux projects on this machine"**:
-
-### Step 4a: Scan for Flux projects
+**Fallback — CHANGELOG.md from marketplace dir:**
 
 ```bash
-# Find all directories with .flux/ on the machine
+MARKETPLACE_DIR="$HOME/.claude/plugins/marketplaces/nairon-flux"
+cat "$MARKETPLACE_DIR/CHANGELOG.md"
+```
+
+Parse entries between the old and new version headers.
+
+## Step 4: Build the "What's New" summary
+
+From the release notes, produce a concise, non-technical summary. The user wants to know **why this upgrade was worth it**, not what files changed.
+
+**Rules:**
+- Group into 2-4 themes max (e.g., "Better planning", "New security tools")
+- Each theme: 1-2 sentences on the benefit
+- Skip version bumps, CI fixes, internal refactors
+- If a new skill/command was added, name it and say what it does in one line
+- If something was fixed, say what was broken and that it works now
+
+**Format:**
+
+```
+## What's new since v{OLD_VERSION}
+
+**[Theme]** — [1-2 sentence benefit]
+
+**[Theme]** — [1-2 sentence benefit]
+```
+
+If changes are minor (one patch version), a single short paragraph is fine.
+
+## Step 5: Determine if `/flux:setup` needs re-running
+
+Scan the release notes/changelog for setup-relevant changes. This is NOT a blind version comparison — it's a content-based decision.
+
+**Re-run IS needed when the changelog mentions:**
+- New MCP servers, CLI tools, desktop apps, or skills added to the setup menu
+- CLAUDE.md markers or instruction format changes
+- fluxctl new subcommands requiring PATH setup
+- `.flux/` directory structure changes
+
+**Re-run is NOT needed when** (most upgrades):
+- Only plugin-level skills/commands changed
+- Bug fixes, docs changes, CI improvements
+- New plugin-only features (e.g., `/flux:score`)
+
+## Step 6: Report to the user
+
+Present a clean upgrade report:
+
+```
+Flux upgraded: v{OLD_VERSION} → v{NEW_VERSION}
+```
+
+Then the "What's New" summary from Step 4.
+
+Then next steps — adapt based on Step 5:
+
+**If setup re-run IS needed:**
+
+```
+## What to do now
+
+1. Restart Claude Code to load the new version
+   (use --resume to keep your current context)
+
+2. After restart, run /flux:setup to pick up new options:
+   [1-line explanation of what's new in setup]
+
+Your existing project files were not modified.
+Setup will only offer new options — nothing you've configured will change.
+```
+
+**If setup re-run is NOT needed:**
+
+```
+## What to do now
+
+Restart Claude Code to load the new version.
+(Use --resume to keep your current context.)
+
+That's it — no need to re-run /flux:setup.
+All changes in this upgrade are plugin-level and activate after restart.
+```
+
+## Step 7 (optional): Batch project upgrade
+
+If the user asks to upgrade multiple projects, or if you detect this is relevant:
+
+### Scan for Flux projects
+
+```bash
 find ~/Developer ~/Projects ~/Code ~/repos ~/src ~/work ~/Desktop ~ -maxdepth 4 -name ".flux" -type d 2>/dev/null | while read flux_dir; do
   project_dir="$(dirname "$flux_dir")"
   version="unknown"
@@ -63,61 +144,6 @@ find ~/Developer ~/Projects ~/Code ~/repos ~/src ~/work ~/Desktop ~ -maxdepth 4 
 done | sort -u | head -30
 ```
 
-Present the list:
+Present the list and ask which to upgrade. For each selected project, update `.flux/bin/` scripts and CLAUDE.md markers only. **Never touch** `.flux/tasks/`, `.flux/epics/`, `.flux/preferences.json`, `.mcp.json`, or user data.
 
-```
-Found Flux in these projects:
-
-  Project                          Setup Version
-  /Users/you/project-a             v2.9.0
-  /Users/you/project-b             v2.10.1
-  /Users/you/test-repo             v2.10.1-dev
-
-Select which to upgrade, or "all".
-```
-
-Use `AskUserQuestion`:
-- "Upgrade all of them"
-- "Let me pick" → show list, let user select
-- "Cancel — just this project"
-
-### Step 4b: Batch upgrade
-
-For each selected project, report what will happen:
-
-```
-Upgrading /Users/you/project-a (v2.9.0 → v2.11.0)...
-  - Updating .flux/bin/ scripts
-  - Merging new config keys into .flux/config.json
-  - Refreshing CLAUDE.md flux markers
-  ✓ Done
-
-Upgrading /Users/you/project-b (v2.10.1 → v2.11.0)...
-  - Updating .flux/bin/ scripts
-  - Merging new config keys into .flux/config.json
-  - No CLAUDE.md changes needed
-  ✓ Done
-```
-
-For each project, run the equivalent of `fluxctl init --json` in that directory, then copy updated bin scripts and refresh the CLAUDE.md markers. Do NOT touch `.flux/tasks/`, `.flux/epics/`, `.flux/preferences.json`, or any user data.
-
-**Important:** The batch upgrade only updates Flux infrastructure files. It never modifies:
-- `.flux/tasks/` or `.flux/epics/` (user work)
-- `.flux/preferences.json` (user preferences)
-- `.mcp.json` (project-specific MCP config — may differ per project)
-- `.claude/skills/` installed from other sources
-
-## Step 5: Report
-
-```
-Flux upgrade complete.
-
-Plugin: v2.10.1 → v2.11.0
-Projects updated: 3/3
-
-Next steps:
-- Restart Claude Code with --resume to load the new plugin
-- Skills and config are already updated in each project
-```
-
-If any project failed, list it with the error so the user can fix manually.
+Report per-project results and flag any failures for manual follow-up.

--- a/skills/flux-upgrade/SKILL.md
+++ b/skills/flux-upgrade/SKILL.md
@@ -6,7 +6,7 @@ user-invocable: true
 
 # Upgrade Flux
 
-Upgrades the Flux plugin to the latest version from GitHub. Handles all three layers of the plugin cache that Claude Code maintains.
+Upgrades the Flux plugin to the latest version from GitHub. Handles all three layers of the plugin cache, shows the user what changed, and tells them exactly what to do next.
 
 ## What This Does
 
@@ -29,6 +29,8 @@ INSTALLED_JSON="$HOME/.claude/plugins/installed_plugins.json"
 OLD_VERSION=$(jq -r '.plugins["flux@nairon-flux"][0].version // "unknown"' "$INSTALLED_JSON" 2>/dev/null || echo "unknown")
 echo "Current version: $OLD_VERSION"
 ```
+
+Save `OLD_VERSION` — you'll need it for the changelog summary later.
 
 ### Step 2: Refresh marketplace metadata
 
@@ -89,7 +91,63 @@ jq --arg v "$NEW_VERSION" \
 echo "Install record updated to $NEW_VERSION"
 ```
 
-### Step 6: Check if setup needs re-run
+### Step 6: Fetch what changed (release notes)
+
+This is the key step that makes the upgrade feel useful. Fetch GitHub release notes for every version between `OLD_VERSION` and `NEW_VERSION`:
+
+```bash
+# Get all releases between old and new version
+gh release list --repo Nairon-AI/flux --limit 30 --json tagName,name,body,publishedAt 2>/dev/null
+```
+
+From the JSON output, filter to only releases where the tag (stripped of `v` prefix) is:
+- Greater than `OLD_VERSION`
+- Less than or equal to `NEW_VERSION`
+
+Use semver comparison (`sort -V`) to determine which releases fall in range.
+
+If `gh` is not available or the API call fails, fall back to reading `CHANGELOG.md` from the marketplace dir:
+
+```bash
+MARKETPLACE_DIR="$HOME/.claude/plugins/marketplaces/nairon-flux"
+cat "$MARKETPLACE_DIR/CHANGELOG.md"
+```
+
+Parse the changelog to extract entries between the old and new version headers.
+
+### Step 7: Build the "What's New" summary
+
+From the release notes or changelog entries gathered in Step 6, produce a **concise, non-technical summary** of what improved. This is what the user actually cares about.
+
+**Rules for the summary:**
+- Lead with benefits, not implementation details
+- Group changes into 2-4 themes max (e.g., "Better planning", "New security scanning", "Faster setup")
+- Each theme gets 1-2 sentences explaining the value
+- Skip version bump PRs, CI fixes, and internal refactors — they don't matter to the user
+- Skip individual file changes — the user doesn't care which `.md` was edited
+- If a new skill/command was added, name it and say what it does in one line
+- If something was fixed, say what was broken and that it's now fixed
+
+**Output format:**
+
+```
+## What's new since v{OLD_VERSION}
+
+**[Theme 1 — e.g., "Smarter scoping"]**
+[1-2 sentences on the benefit. Example: "The /flux:scope command now tracks your progress
+through each phase, so you can pick up where you left off after a restart."]
+
+**[Theme 2 — e.g., "Built-in code maps"]**
+[1-2 sentences. Example: "Flux now generates project structure maps natively — no need to
+install the separate agentmap CLI anymore."]
+
+**[Theme 3 — e.g., "Bug fixes"]**  *(only if meaningful fixes)*
+[Brief description of what was broken and that it works now.]
+```
+
+If only one version was skipped and changes are minor, a single paragraph is fine — no need for themes.
+
+### Step 8: Check if setup needs re-run
 
 Compare the new plugin version to `setup_version` in `.flux/meta.json`:
 
@@ -99,28 +157,76 @@ echo "Setup version: $SETUP_VER"
 echo "Plugin version: $NEW_VERSION"
 ```
 
-If `SETUP_VER` != `NEW_VERSION` (or is "none"), the upgrade may include new setup options.
+Determine whether `/flux:setup` needs to be re-run. This depends on **what changed**, not just version drift:
 
-### Step 7: Report result
+**Setup re-run IS needed when** (check changelog/release notes for these):
+- New MCP servers were added to the setup menu
+- New CLI tools or desktop apps were added to the setup menu
+- New skills became installable through setup
+- CLAUDE.md markers or instructions format changed
+- fluxctl got new subcommands that need PATH setup
+- The `.flux/` directory structure changed (new directories, renamed files)
 
-Tell the user to restart Claude Code to load the new version:
+**Setup re-run is NOT needed when** (most upgrades):
+- Only skills/commands within the plugin changed (these load from the plugin, not `.flux/`)
+- Bug fixes to existing behavior
+- Release process or CI improvements
+- Documentation-only changes
+- New plugin-only features (like `/flux:score`, `/flux:security-scan`)
+
+**How to determine this**: Scan the release notes/changelog entries from Step 6. Look for mentions of `/flux:setup`, `CLAUDE.md`, `fluxctl`, `.flux/bin`, `meta.json`, MCP, CLI tool, desktop app, or skill install changes. If none are found, setup re-run is NOT needed.
+
+### Step 9: Report result
+
+Present the full upgrade report to the user. The format adapts based on what happened:
+
+**Always show:**
 
 ```
-✅ Flux upgraded: v{OLD_VERSION} → v{NEW_VERSION}
-
-Restart Claude Code now to load the new version (use --resume to keep context).
-Your project setup (.flux/, brain vault, CLAUDE.md) was not modified.
+Flux upgraded: v{OLD_VERSION} → v{NEW_VERSION}
 ```
 
-If setup version is stale, add:
+**Then show the "What's New" summary from Step 7.**
 
+**Then show next steps:**
+
+If setup re-run IS needed:
 ```
-⚠️ Your project setup (v{SETUP_VER}) is behind the plugin (v{NEW_VERSION}).
-New configuration options may be available. Run /flux:setup after restart to update.
+## What to do now
+
+1. Restart Claude Code to load the new version
+   (use `--resume` to keep your current context)
+
+2. After restart, run `/flux:setup` to pick up new options:
+   [1-line explanation of what's new in setup, e.g., "New Expect browser QA tool
+   and X Research skill are now available in the setup menu."]
+
+Your existing project files (.flux/, brain vault, CLAUDE.md) were not modified.
+Setup will only add new options — it won't change anything you've already configured.
+```
+
+If setup re-run is NOT needed:
+```
+## What to do now
+
+Restart Claude Code to load the new version.
+(Use `--resume` to keep your current context.)
+
+That's it — no need to re-run `/flux:setup`. All changes in this
+upgrade are plugin-level and will be active after restart.
+Your project files (.flux/, brain vault, CLAUDE.md) were not modified.
+```
+
+If already on latest (from Step 3):
+```
+You're already on the latest version (v{OLD_VERSION}).
+No upgrade needed.
 ```
 
 ## Gotchas
 
 - Upgrade is not complete until Claude restarts and reloads the plugin. Clearing cache without restart still leaves the running session on the old code.
-- `setup_version` drift matters. The plugin can be upgraded successfully while the repo-local setup remains stale and misses new options.
+- `setup_version` drift does NOT always mean re-run is needed. Only recommend re-running setup when the changelog shows setup-relevant changes. False "re-run setup" warnings erode trust.
+- The `gh` CLI is the preferred source for release notes (richer content). Fall back to CHANGELOG.md only when `gh` is unavailable or fails.
 - This skill is for Flux/plugin upgrades, not for upgrading arbitrary project dependencies.
+- If `OLD_VERSION` is "unknown" (first-time or corrupted state), skip the changelog diff and just show the latest release notes as the summary.


### PR DESCRIPTION
## Summary

- **Upgrade now shows what changed** — fetches GitHub release notes between old and new version, then presents a concise "What's New" summary grouped by themes (not file lists or commit hashes)
- **Setup re-run guidance is content-based** — instead of always warning when `setup_version != plugin_version`, it scans the actual changelog for setup-relevant changes (new MCP servers, CLI tools, CLAUDE.md format changes). Most upgrades correctly say "no re-run needed"
- **Aligned SKILL.md and upgrade.md** — previously had conflicting workflows; now both follow the same logical flow with batch upgrade moved to an optional step

## Test plan

- [ ] Run `/flux:upgrade` when already on latest — should say "no upgrade needed" and stop
- [ ] Run `/flux:upgrade` from an older version — should show themed "What's New" summary
- [ ] Verify `gh release list` fallback to CHANGELOG.md when `gh` CLI unavailable
- [ ] Confirm setup re-run is only recommended when changelog has setup-relevant changes
- [ ] Verify batch project scan still works as optional Step 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)