### PR TITLE
feat: external memory MCP detection and routing

### DIFF
--- a/scripts/detect-installed.sh
+++ b/scripts/detect-installed.sh
@@ -142,6 +142,21 @@ detect_linux_apps() {
     printf '%s\n' "${apps[@]}" | sort -u | jq -R . | jq -s .
 }
 
+# Known memory MCP names — used to detect external memory providers
+KNOWN_MEMORY_MCPS="supermemory supermemory-ai mem0 memory obsidian obsidian-mcp"
+
+# Classify which installed MCPs are memory providers
+classify_memory_mcps() {
+    local all_mcps="$1"
+    local matches="[]"
+    for name in $KNOWN_MEMORY_MCPS; do
+        if echo "$all_mcps" | jq -e --arg n "$name" 'index($n)' >/dev/null 2>&1; then
+            matches=$(echo "$matches" | jq --arg n "$name" '. + [$n]')
+        fi
+    done
+    echo "$matches"
+}
+
 # Detect MCPs from ~/.mcp.json
 detect_mcps() {
     local global_file="$HOME/.mcp.json"
@@ -245,12 +260,16 @@ main() {
         *)      apps="[]" ;;
     esac
     
+    # Classify memory MCPs from the detected set
+    local memory_mcps=$(classify_memory_mcps "$mcps")
+
     # Combine into JSON
     jq -n \
         --arg os "$os" \
         --argjson cli_tools "$cli_tools" \
         --argjson apps "$apps" \
         --argjson mcps "$mcps" \
+        --argjson memory_mcps "$memory_mcps" \
         --argjson plugins "$plugins" \
         --argjson preferences "$preferences" \
         --argjson warnings "$warnings" \
@@ -260,6 +279,7 @@ main() {
                 cli_tools: $cli_tools,
                 applications: $apps,
                 mcps: $mcps,
+                memory_mcps: $memory_mcps,
                 plugins: $plugins
             },
             preferences: $preferences,

--- a/skills/flux-brain/SKILL.md
+++ b/skills/flux-brain/SKILL.md
@@ -21,23 +21,41 @@ The brain is the foundation of the entire workflow — every agent, skill, and s
 
 When the user says "remember X", "don't forget X", "keep in mind X", or similar — first decide whether it belongs in **CLAUDE.md** or the **brain vault**, then ask the user to confirm.
 
-### Step 1: CLAUDE.md vs Brain
+### Step 0: Check for external memory provider
+
+Before routing, check if an external memory MCP is configured:
+
+```bash
+PLUGIN_ROOT="${DROID_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}"
+[ -z "$PLUGIN_ROOT" ] && PLUGIN_ROOT=$(ls -td ~/.claude/plugins/cache/nairon-flux/flux/*/ 2>/dev/null | head -1)
+FLUXCTL="${PLUGIN_ROOT}/scripts/fluxctl"
+EXTERNAL_MEMORY_PROVIDER=$($FLUXCTL config get externalMemory.provider --json 2>/dev/null | jq -r '.value // empty')
+EXTERNAL_MEMORY_TOOL=$($FLUXCTL config get externalMemory.tool --json 2>/dev/null | jq -r '.value // empty')
+```
+
+If `EXTERNAL_MEMORY_PROVIDER` is set, a third destination is available (see Step 2 below).
+
+### Step 1: CLAUDE.md vs Brain (vs External Memory)
 
 Use this heuristic to pre-select the right destination:
 
-| Goes in **CLAUDE.md** | Goes in **.flux/brain/** |
-|---|---|
-| Short, actionable rules the agent needs **every session** | Deeper knowledge, context, or rationale |
-| Commands and how to run them ("use `pnpm test`", "run `make build`") | Why a decision was made ("we chose Supabase because...") |
-| Hard constraints ("never import from `legacy/`", "always use TypeScript") | Business context ("Sarah is the PM", "we have 500 users") |
-| Code style rules ("use camelCase for APIs", "4-space indent") | Pitfalls and lessons learned ("migration script doesn't handle NULLs") |
-| Things that affect every task regardless of domain | Things that are relevant only in certain contexts |
+| Goes in **CLAUDE.md** | Goes in **.flux/brain/** | Goes in **external memory** |
+|---|---|---|
+| Short, actionable rules the agent needs **every session** | Deeper knowledge, context, or rationale | Personal preferences that span repos |
+| Commands and how to run them ("use `pnpm test`", "run `make build`") | Why a decision was made ("we chose Supabase because...") | Cross-project patterns ("I prefer single PRs for refactors") |
+| Hard constraints ("never import from `legacy/`", "always use TypeScript") | Business context ("Sarah is the PM", "we have 500 users") | Personal tool preferences ("I use Vim keybindings everywhere") |
+| Code style rules ("use camelCase for APIs", "4-space indent") | Pitfalls and lessons learned ("migration script doesn't handle NULLs") | Learning notes not tied to this repo |
+| Things that affect every task regardless of domain | Things that are relevant only in certain contexts | Things that are relevant across multiple repos |
 
-**Rule of thumb:** If the agent would need this to avoid a mistake on *any* task in the project, it's CLAUDE.md. If it's context that helps make *better* decisions in specific situations, it's brain.
+**Rule of thumb:** If the agent would need this to avoid a mistake on *any* task in the project, it's CLAUDE.md. If it's context that helps make *better* decisions in specific situations, it's brain. If it's personal knowledge that helps across *all* your projects, it's external memory.
+
+**Note:** The external memory column only applies when `externalMemory.provider` is configured. If not set, route between CLAUDE.md and brain as before.
 
 ### Step 2: Ask the user
 
-Use `AskUserQuestion` with the pre-selected option first:
+Use `AskUserQuestion` with the pre-selected option first.
+
+**If `EXTERNAL_MEMORY_PROVIDER` is NOT set** (default — two options):
 
 ```json
 {
@@ -58,6 +76,34 @@ Use `AskUserQuestion` with the pre-selected option first:
   }]
 }
 ```
+
+**If `EXTERNAL_MEMORY_PROVIDER` IS set** (three options — add external memory):
+
+```json
+{
+  "questions": [{
+    "question": "Where should I store this?",
+    "header": "Remember",
+    "multiSelect": false,
+    "options": [
+      {
+        "label": "CLAUDE.md — agent reads every session",
+        "description": "Short, actionable rules and constraints (e.g., 'always use pnpm', 'never import from legacy/'). The agent sees this at the start of every conversation."
+      },
+      {
+        "label": "Brain vault — repo-specific context",
+        "description": "Decisions, business context, principles, pitfalls for THIS repo. Git-tracked, shared with team."
+      },
+      {
+        "label": "{EXTERNAL_MEMORY_PROVIDER} — cross-project, personal",
+        "description": "Personal knowledge that spans repos. Not git-tracked. Use for preferences, patterns, and learnings that apply everywhere."
+      }
+    ]
+  }]
+}
+```
+
+Replace `{EXTERNAL_MEMORY_PROVIDER}` with the actual provider name (e.g., "Supermemory", "Mem0").
 
 ### Step 3a: If CLAUDE.md selected
 
@@ -113,6 +159,19 @@ Then:
 4. Update `.flux/brain/index.md` to include a link to the new file
 
 Notes are prunable — `/flux:meditate` audits and removes stale ones. Store freely.
+
+### Step 3c: If external memory selected
+
+When the user chooses the external memory option, use the provider's MCP tool to store the knowledge. Do NOT write to `.flux/brain/` or CLAUDE.md.
+
+1. Format the learning as a concise note (same style as brain vault — bullets over prose)
+2. Call the external memory MCP tool to store it. The tool name is in `EXTERNAL_MEMORY_TOOL`. Example for Supermemory:
+   - Use the MCP tool `search_supermemory_memory_api_for` to first check if a similar memory already exists
+   - If it exists, inform the user: "This is already stored in {EXTERNAL_MEMORY_PROVIDER} — skipping."
+   - If it does not exist, use the appropriate MCP write/add tool to store the new memory
+3. Confirm to the user: "Stored in {EXTERNAL_MEMORY_PROVIDER} (not git-tracked)."
+
+**Important:** Never silently write to external memory. The user explicitly chose this destination in Step 2. If the MCP tool call fails (provider down, auth expired), fall back to brain vault and tell the user why.
 
 ## Before Writing
 

--- a/skills/flux-reflect/SKILL.md
+++ b/skills/flux-reflect/SKILL.md
@@ -29,6 +29,43 @@ On completion, reset:
 $FLUXCTL session-phase set idle
 ```
 
+## External Memory Awareness
+
+Before processing learnings, check if an external memory provider is configured:
+
+```bash
+PLUGIN_ROOT="${DROID_PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}"
+[ -z "$PLUGIN_ROOT" ] && PLUGIN_ROOT=$(ls -td ~/.claude/plugins/cache/nairon-flux/flux/*/ 2>/dev/null | head -1)
+FLUXCTL="${PLUGIN_ROOT}/scripts/fluxctl"
+EXTERNAL_MEMORY_PROVIDER=$($FLUXCTL config get externalMemory.provider --json 2>/dev/null | jq -r '.value // empty')
+EXTERNAL_MEMORY_TOOL=$($FLUXCTL config get externalMemory.tool --json 2>/dev/null | jq -r '.value // empty')
+```
+
+If `EXTERNAL_MEMORY_PROVIDER` is set, two additional behaviors activate:
+
+1. **Dedup on write** — before writing a learning to `.flux/brain/`, query the external memory MCP to check if it already exists externally. If a close match is found, skip the brain write and log: "Already in {provider} — skipping brain write for: {topic}". This prevents the same insight living in both places.
+
+2. **Personal-scope routing** — when a learning is personal/cross-project (not repo-specific), offer to store it in the external provider instead of brain. Use `AskUserQuestion`:
+
+```json
+{
+  "questions": [{
+    "question": "This learning seems personal/cross-project. Store in {EXTERNAL_MEMORY_PROVIDER} instead of brain vault?",
+    "header": "Learning: {one-line summary}",
+    "multiSelect": false,
+    "options": [
+      {"label": "Yes — store in {EXTERNAL_MEMORY_PROVIDER}", "description": "Cross-project, personal, not git-tracked"},
+      {"label": "No — store in brain vault", "description": "Repo-specific, git-tracked, shared with team"},
+      {"label": "Skip", "description": "Don't store this learning anywhere"}
+    ]
+  }]
+}
+```
+
+**Heuristic for personal vs repo-scoped:** A learning is personal if it's about the user's preferences, workflow habits, tool choices, or general engineering patterns that aren't specific to this codebase. A learning is repo-scoped if it references specific files, APIs, architecture, team members, or project decisions.
+
+If `EXTERNAL_MEMORY_PROVIDER` is NOT set, skip both behaviors — reflect works exactly as before.
+
 ## Process
 
 1. **Read `.flux/brain/index.md`** to understand what notes already exist
@@ -117,6 +154,8 @@ Follow-up work that can't be done during reflection — bugs, non-trivial rewrit
 ```
 ## Reflect Summary
 - Brain: [files created/updated, one-line each]
+- External memory: [learnings routed to {provider}, one-line each] (only if external memory is configured)
+- Dedup skipped: [learnings already in {provider}, one-line each] (only if any were deduped)
 - Skills extracted: [new skill files created, one-line each]
 - Skills updated: [existing skill files modified, one-line each]
 - Structural: [rules/scripts/checks added]

--- a/skills/flux-setup/workflow.md
+++ b/skills/flux-setup/workflow.md
@@ -435,6 +435,57 @@ Store for summary:
 - `SKIPPED_MCPS` — list of MCPs user chose to skip
 - `CONFLICTS_RESOLVED` — list of conflict resolutions made
 
+### Detect external memory MCPs
+
+After MCP installation, check whether the user already has an external memory provider configured. This determines whether `flux-brain` and `flux-reflect` should offer cross-project routing.
+
+Known memory MCPs: `supermemory`, `supermemory-ai`, `mem0`, `memory`, `obsidian`, `obsidian-mcp`.
+
+```bash
+KNOWN_MEMORY_MCPS="supermemory supermemory-ai mem0 memory obsidian obsidian-mcp"
+DETECTED_MEMORY_MCP=""
+
+for name in $KNOWN_MEMORY_MCPS; do
+  if echo "$MCP_LIST" | grep -qx "$name"; then
+    DETECTED_MEMORY_MCP="$name"
+    break
+  fi
+done
+```
+
+If a memory MCP is detected:
+
+1. **Log advisory** — tell the user what this means:
+
+```
+External memory detected: {DETECTED_MEMORY_MCP}
+  → Brain vault (.flux/brain/) will handle repo-specific knowledge
+  → Cross-project/personal preferences should go to {DETECTED_MEMORY_MCP}
+  → flux-brain and flux-reflect will offer {DETECTED_MEMORY_MCP} as a destination for personal-scope learnings
+```
+
+2. **Write to config** — record the provider so downstream skills can check it:
+
+```bash
+if [ -n "$DETECTED_MEMORY_MCP" ]; then
+  "$PLUGIN_ROOT/scripts/fluxctl" config set externalMemory.provider "$DETECTED_MEMORY_MCP"
+
+  # Map provider to its MCP search tool name
+  case "$DETECTED_MEMORY_MCP" in
+    supermemory|supermemory-ai) MEMORY_TOOL="search_supermemory_memory_api_for" ;;
+    mem0)                       MEMORY_TOOL="search_mem0" ;;
+    obsidian|obsidian-mcp)      MEMORY_TOOL="search_obsidian" ;;
+    *)                          MEMORY_TOOL="" ;;
+  esac
+
+  [ -n "$MEMORY_TOOL" ] && "$PLUGIN_ROOT/scripts/fluxctl" config set externalMemory.tool "$MEMORY_TOOL"
+fi
+```
+
+3. **Track for summary** — add `DETECTED_MEMORY_MCP` to the Step 8 summary output.
+
+If no memory MCP is detected, skip silently — no config is written, and brain/reflect behave as before.
+
 ### Manual fallback
 
 If settings are not writable or `jq` is missing, print manual instructions:


### PR DESCRIPTION
## Summary

- Detects external memory MCPs (Supermemory, Mem0, Obsidian) during `flux:setup` and records the provider in `.flux/config.json`
- `flux-brain` "Remember" flow gains a third destination option when an external memory provider is configured — routes personal/cross-project knowledge to the external provider instead of brain vault
- `flux-reflect` checks external memory for duplicates before writing to brain, and offers personal-scope routing for cross-project learnings
- `detect-installed.sh` classifies memory MCPs separately in its output (`installed.memory_mcps`)

All behavior is gated on `externalMemory.provider` config — zero change for users without a memory MCP.

## Test plan

- [ ] Run `scripts/detect-installed.sh` with Supermemory MCP configured — verify `memory_mcps` array in output
- [ ] Run `scripts/detect-installed.sh` without any memory MCP — verify `memory_mcps` is empty array
- [ ] Run `/flux:setup` with Supermemory MCP present — verify advisory is logged and `externalMemory.provider` is written to config
- [ ] Run `/flux:setup` without memory MCP — verify no `externalMemory` config is written
- [ ] Test "remember X" flow with external memory configured — verify third option appears in AskUserQuestion
- [ ] Test "remember X" flow without external memory — verify only two options (no regression)
- [ ] Test `/flux:reflect` with external memory — verify dedup check runs before brain writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)