### PR TITLE
[codex] Add React Doctor opt-in setup with pre-commit hook wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ After setup, just talk to the agent. Flux parses your message intent and routes 
 | [Lefthook](https://github.com/evilmartians/lefthook) | Fast git hooks for pre-commit checks |
 | [agent-browser](https://github.com/nichochar/agent-browser) | Headless browser for automated UI QA during epic reviews |
 | [CLI Continues](https://github.com/nichochar/continues) | Session handoff — pick up where you left off across terminals |
+| [React Doctor](https://www.react.doctor/) | Diff-scoped React code health scan with an opt-in pre-commit gate for changed files |
 | [PlaTo](https://github.com/Alt5r/Plato) | Secure skill installer for Codex and Claude — signs and verifies project-local skills before runtime exposure |
 
 **Desktop Apps** (macOS):
@@ -133,8 +134,10 @@ After setup, just talk to the agent. Flux parses your message intent and routes 
 | [Find Skills (Vercel)](https://github.com/vercel-labs/agent-skills) | Secure bootstrap for Vercel's skill catalog, then add more through PlaTo |
 | [X Research Skill](https://github.com/rohunvora/x-research-skill) | Summarize high-signal X threads for research |
 
-`Dejank` is only offered when Flux detects a React-based repo during setup.
-After it is installed, trigger it explicitly with `/flux:dejank` or by directly asking the agent to use `dejank`.
+`React Doctor` and `Dejank` are only offered when Flux detects a React-based repo during setup.
+Selecting React Doctor during setup also wires an opt-in pre-commit hook so changed React code gets scanned before commit.
+When React Doctor is available, Flux still uses it again in the quality pass for changed React code before submit.
+Dejank stays the symptom-driven workflow: trigger it explicitly with `/flux:dejank` or by directly asking the agent to use `dejank`.
 Casual React jank complaints like "this flickers" or "the layout jumps" should also route there automatically once Flux is installed in the repo.
 
 </details>
@@ -296,7 +299,7 @@ These utility skills run *inside* the owning phase rather than creating a new to
 | **Work** | Task loop: spawn worker per task with fresh context, brain re-anchor, impl-review after each. Codex is the recommended implementation engine; after each task, Flux checks for friction signals (build errors, lint failures, API hallucinations) and offers targeted tool recommendations inline — install, skip, or snooze for 7 days. Snoozed signals automatically resurface to check for new tooling. In Ralph mode, this loop runs autonomously without stopping. | Long tasks degrade agent quality — context bloats, the agent forgets constraints, output gets sloppy. Fresh workers per task keep context tight. Inline friction detection catches recurring pain points *during* the build, not after — so you can unblock immediately instead of suffering through an entire epic before getting a recommendation. |
 | **Review** | Per-task lightweight (`impl-review`), per-epic thorough (`epic-review` — adversarial, security, BYORB *optional*, browser QA, learning capture). Review handling uses `flux-receive-review` to interpret reviewer/bot comments before code changes and `flux-verify-claims` before advancing to SHIP. Manual review findings can also be structuralized: if the developer confirms a repeatable anti-pattern, Flux can route it toward a project rule candidate (for example a `lintcn` rule). Codex handles the primary review backend; Claude is still a strong adversarial reviewer in cross-lab pairings. | Self-review is unreliable — the same model that wrote the code reviews it. Adversarial review (multiple models reaching consensus) catches what single-model review misses. BYORB (Greptile, CodeRabbit, etc.) is optional — skipped if no bot is configured. Browser QA catches what code review can't see at all. |
 | **Grill** | *After Epic Review (offered for 5+ task epics):* Relentless behavioral stress test — walks every branch of the decision tree, verifying implemented behavior matches intent. Finds gaps the spec didn't mention but users will encounter. Can create new tasks if gaps are found. | Epic review checks code quality — but code can be perfect and still do the wrong thing. Grill checks *behavioral correctness*: does the implementation match what was intended? It's the difference between "the code compiles" and "the feature works." Especially valuable for large epics where requirements can drift across many tasks. |
-| **Quality** | Tests, repo-defined lint/format gates (for example `lintcn`), desloppify scan on changed files. | Agents skip tests, ignore lint errors, and leave dead code. Quality is the gate before Submit — nothing ships without passing. |
+| **Quality** | Tests, repo-defined lint/format gates (for example `lintcn`), optional `react-doctor` diff scan for React changes as a backstop after the pre-commit hook, desloppify scan on changed files. | Agents skip tests, ignore lint errors, and leave dead code. Quality is the gate before Submit — nothing ships without passing. |
 | **Submit** | Push + open PR. Code is ready for review/merge. | Separates "code is done" from "code is shipped." The PR is the handoff point where human reviewers and CI take over. |
 | **Autofix** | *Automatic after Submit (config-driven):* optional Anthropic-backed cloud PR babysitting after the main Codex implementation path is done. Non-blocking — Reflect runs independently. Enabled via `/flux:setup`. | CI failures and review comments are the #1 reason PRs sit idle. Auto-fix handles the mechanical back-and-forth after shipping, while keeping core implementation and review Codex-first. |
 | **Reflect** | *Auto after Submit/Autofix:* captures session learnings to brain vault, extracts reusable skills, and routes confirmed recurring review findings into structural prevention where appropriate (lint rules, guards, scripts) while context is fresh. | The agent just spent an entire session learning your codebase, hitting bugs, getting corrected. If you don't capture those learnings *now*, they're gone — the next session starts from scratch. Reflect is the difference between an agent that gets smarter over time and one that makes the same mistakes forever. |
@@ -414,7 +417,7 @@ The result: Flux gets smarter every session — new tools surface proactively, f
 
 Systematic code quality improvement powered by [desloppify](https://github.com/peteromallet/desloppify). Combines mechanical detection with LLM-based review. The scoring system resists gaming — you can't suppress warnings, you have to actually fix the code.
 
-When installed, Flux automatically runs a lightweight desloppify scan after epic review to surface quality regressions introduced during the epic. If the score drops below 85, it suggests a full fix pass.
+When installed, Flux automatically runs a lightweight desloppify scan after epic review to surface quality regressions introduced during the epic. In React repos where React Doctor is available, Flux also runs a diff-scoped React Doctor pass during quality before submit. If the desloppify score drops below 85, it suggests a full fix pass.
 
 ```bash
 /flux:desloppify scan     # See your score

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -122,7 +122,7 @@ Use `--deep` for high-stakes or ambiguous features.
 <p><em>Coming soon</em></p>
 </details>
 
-Initializes Flux in your project. Creates `.flux/`, the canonical brain vault at `.flux/brain/`, and the centralized architecture note at `.flux/brain/codebase/architecture.md`, then configures preferences and optionally installs productivity tools (MCP servers, CLI tools, desktop apps). Supported skill installs now go through PlaTo so Flux can use a signed, verified `.secureskills/` store.
+Initializes Flux in your project. Creates `.flux/`, the canonical brain vault at `.flux/brain/`, and the centralized architecture note at `.flux/brain/codebase/architecture.md`, then configures preferences and optionally installs productivity tools (MCP servers, CLI tools, desktop apps). Supported skill installs now go through PlaTo so Flux can use a signed, verified `.secureskills/` store. In React-based repos, setup can also offer React Doctor as an optional CLI and wire it into a pre-commit hook, with the quality pass re-running it as a backstop before submit.
 
 ### /flux:plan
 
@@ -142,7 +142,7 @@ Breaks down an idea into atomic tasks with dependencies and acceptance criteria.
 <p><em>Coming soon</em></p>
 </details>
 
-Executes a task with automatic context reload and drift checks.
+Executes a task with automatic context reload and drift checks. During the quality pass, React-based repos can also run a diff-scoped React Doctor scan when the tool is available, even if the pre-commit hook already ran.
 
 The underlying `fluxctl` helper also exposes:
 
@@ -329,6 +329,8 @@ Flux classifies the content and asks you to confirm the destination before writi
 | `/flux:plan-review` | `/flux:plan-review <fn-N> [--review=rp\|codex\|export]` | Review plan quality before execution |
 | `/flux:impl-review` | `/flux:impl-review [--review=rp\|codex\|export]` | Review implementation quality |
 | `/flux:epic-review` | `/flux:epic-review <fn-N> [--review=rp\|codex\|none]` | Confirm epic completion aligns with spec |
+
+React-based repos can add an extra static gate here: when `react-doctor` is installed or runnable via `npx`, Flux runs `react-doctor . --diff HEAD --fail-on error` before submit.
 
 ---
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -34,7 +34,7 @@ Every Flux session begins with a state check (`fluxctl session-state --json`). T
 | `plan_sync` | Update downstream todo tasks based on implementation drift. | `in_progress` (next task) | Plan Sync |
 | `needs_completion_review` | All tasks done. Epic review required. | `epic_review` | Epic Review |
 | `epic_review` | Full review pipeline running. | `quality` (SHIP), `in_progress` (NEEDS_WORK fix loop) | Epic Review Pipeline |
-| `quality` | Tests, repo-defined lint/format gates (for example `lintcn`), desloppify scan on changed files. | `submit` | Quality |
+| `quality` | Tests, repo-defined lint/format gates (for example `lintcn`), optional React Doctor diff scan for React changes, desloppify scan on changed files. | `submit` | Quality |
 | `grill` | Behavioral stress test — walks decision tree verifying behavior matches intent. | `quality`, `in_progress` (if gaps found) | Grill |
 | `submit` | Push + open PR. Code ready for review/merge. | `autofix`, `reflect` | Submit |
 | `autofix` | Cloud auto-fix enabled on PR — Claude watches for CI failures and review comments remotely. Non-blocking. | `reflect` | Autofix |
@@ -266,7 +266,7 @@ RECOMMENDATION PULSE (recommendation_pulse)
   │    │ all verified            │
   │    ▼                        ▼
   │  QUALITY (quality)
-  │  → tests, repo-defined lint/format gates, desloppify scan
+  │  → tests, repo-defined lint/format gates, optional react-doctor diff scan, desloppify scan
   │        │
   │        ▼
   │  SUBMIT (submit)

--- a/scripts/detect-installed.sh
+++ b/scripts/detect-installed.sh
@@ -70,6 +70,7 @@ detect_cli_tools() {
 
     # Agent workflow automation
     cmd_exists agent-browser && tools+=("agent-browser")
+    cmd_exists react-doctor && tools+=("react-doctor")
     cmd_exists secureskills && tools+=("secureskills")
     if cmd_exists continues || cmd_exists cont; then
         tools+=("cli-continues")

--- a/scripts/install-react-doctor-hook.py
+++ b/scripts/install-react-doctor-hook.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Configure a React Doctor pre-commit hook for the current repo.
+
+Preference order:
+1. Existing Husky setup
+2. Existing Lefthook setup
+3. Fresh Lefthook setup
+4. Native .git/hooks fallback
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+HOOK_RELATIVE_PATH = ".flux/hooks/react-doctor-pre-commit.sh"
+HOOK_RUN = f"./{HOOK_RELATIVE_PATH}"
+HOOK_SCRIPT = """#!/bin/sh
+set -eu
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  exit 0
+fi
+
+if ! git diff --cached --name-only --diff-filter=ACMR | grep -Eq '\\.(jsx?|tsx?)$'; then
+  exit 0
+fi
+
+if git rev-parse --verify HEAD >/dev/null 2>&1; then
+  BASE_REF="HEAD"
+else
+  BASE_REF=$(git hash-object -t tree /dev/null)
+fi
+
+if command -v react-doctor >/dev/null 2>&1; then
+  exec react-doctor . --diff "$BASE_REF" --fail-on error
+fi
+
+if command -v npx >/dev/null 2>&1; then
+  exec npx -y react-doctor@latest . --diff "$BASE_REF" --fail-on error
+fi
+
+echo "react-doctor is not installed and npx is unavailable." >&2
+exit 1
+"""
+
+HUSKY_SNIPPET = f'\n# Flux React Doctor\n"{Path(HOOK_RELATIVE_PATH).as_posix()}"\n'
+NATIVE_SNIPPET = '\n# Flux React Doctor\n"./.flux/hooks/react-doctor-pre-commit.sh"\n'
+
+
+def write_json(payload: dict[str, object], exit_code: int = 0) -> None:
+    print(json.dumps(payload))
+    raise SystemExit(exit_code)
+
+
+def ensure_git_repo(root: Path) -> None:
+    result = subprocess.run(
+        ["git", "rev-parse", "--git-dir"],
+        cwd=root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        write_json(
+            {
+                "success": False,
+                "error": "Not a git repository",
+                "manager": "none",
+                "hook_status": "failed",
+            },
+            1,
+        )
+
+
+def ensure_hook_script(root: Path) -> Path:
+    hook_path = root / HOOK_RELATIVE_PATH
+    hook_path.parent.mkdir(parents=True, exist_ok=True)
+    hook_path.write_text(HOOK_SCRIPT)
+    hook_path.chmod(hook_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return hook_path
+
+
+def update_lefthook_config(config_path: Path) -> str:
+    block = [
+        "pre-commit:",
+        "  commands:",
+        "    react-doctor:",
+        f"      run: {HOOK_RUN}",
+        "",
+    ]
+
+    if not config_path.exists():
+        config_path.write_text("\n".join(block))
+        return "configured"
+
+    text = config_path.read_text()
+    if HOOK_RUN in text or "\n    react-doctor:\n" in text:
+        return "already_configured"
+
+    lines = text.splitlines()
+
+    def root_key(line: str) -> bool:
+        stripped = line.strip()
+        return bool(stripped) and not line.startswith((" ", "\t", "#"))
+
+    pre_idx = next((i for i, line in enumerate(lines) if line.strip() == "pre-commit:"), None)
+    if pre_idx is None:
+        if lines and lines[-1].strip():
+            lines.append("")
+        lines.extend(block[:-1])
+        config_path.write_text("\n".join(lines) + "\n")
+        return "configured"
+
+    end_idx = len(lines)
+    for i in range(pre_idx + 1, len(lines)):
+        if root_key(lines[i]):
+            end_idx = i
+            break
+
+    commands_idx = next(
+        (i for i in range(pre_idx + 1, end_idx) if lines[i].strip() == "commands:"),
+        None,
+    )
+
+    if commands_idx is None:
+        insert_at = end_idx
+        lines[insert_at:insert_at] = [
+            "  commands:",
+            "    react-doctor:",
+            f"      run: {HOOK_RUN}",
+        ]
+    else:
+        insert_at = commands_idx + 1
+        while insert_at < end_idx:
+            current = lines[insert_at]
+            stripped = current.strip()
+            if not stripped or stripped.startswith("#"):
+                insert_at += 1
+                continue
+            indent = len(current) - len(current.lstrip(" "))
+            if indent >= 4:
+                insert_at += 1
+                continue
+            break
+        lines[insert_at:insert_at] = [
+            "    react-doctor:",
+            f"      run: {HOOK_RUN}",
+        ]
+
+    config_path.write_text("\n".join(lines) + "\n")
+    return "configured"
+
+
+def configure_husky(root: Path) -> str:
+    husky_dir = root / ".husky"
+    pre_commit = husky_dir / "pre-commit"
+    husky_dir.mkdir(parents=True, exist_ok=True)
+
+    if pre_commit.exists():
+        text = pre_commit.read_text()
+        if HOOK_RELATIVE_PATH in text:
+            return "already_configured"
+    else:
+        text = '#!/bin/sh\nset -eu\n. "$(dirname "$0")/_/husky.sh"\n'
+
+    if HOOK_RELATIVE_PATH not in text:
+        if not text.endswith("\n"):
+            text += "\n"
+        text += HUSKY_SNIPPET
+
+    pre_commit.write_text(text)
+    pre_commit.chmod(pre_commit.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return "configured"
+
+
+def configure_native_hook(root: Path) -> str:
+    git_dir = subprocess.run(
+        ["git", "rev-parse", "--git-dir"],
+        cwd=root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    hook_path = root / git_dir / "hooks" / "pre-commit"
+    hook_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if hook_path.exists():
+        text = hook_path.read_text()
+        if HOOK_RELATIVE_PATH in text:
+            return "already_configured"
+        if not text.endswith("\n"):
+            text += "\n"
+        text += NATIVE_SNIPPET
+    else:
+        text = "#!/bin/sh\nset -eu\n" + NATIVE_SNIPPET
+
+    hook_path.write_text(text)
+    hook_path.chmod(hook_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return "configured"
+
+
+def maybe_install_lefthook(root: Path) -> str:
+    if os.environ.get("FLUX_SKIP_LEFTHOOK_INSTALL") == "1":
+        return "skipped"
+
+    if shutil.which("lefthook"):
+        command = ["lefthook", "install"]
+    elif shutil.which("npx"):
+        command = ["npx", "-y", "lefthook", "install"]
+    else:
+        return "unavailable"
+
+    result = subprocess.run(
+        command,
+        cwd=root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    return "installed" if result.returncode == 0 else "failed"
+
+
+def main() -> None:
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else ".").resolve()
+    ensure_git_repo(root)
+    hook_path = ensure_hook_script(root)
+
+    has_husky = (root / ".husky").exists()
+    has_lefthook = (root / "lefthook.yml").exists()
+
+    manager = "none"
+    hook_status = "failed"
+    install_status = "not_needed"
+
+    if has_husky:
+        manager = "husky"
+        hook_status = configure_husky(root)
+    else:
+        manager = "lefthook"
+        hook_status = update_lefthook_config(root / "lefthook.yml")
+        install_status = maybe_install_lefthook(root)
+        if install_status in {"failed", "unavailable"}:
+            manager = "git-hooks"
+            hook_status = configure_native_hook(root)
+
+    write_json(
+        {
+            "success": hook_status in {"configured", "already_configured"},
+            "manager": manager,
+            "hook_status": hook_status,
+            "install_status": install_status,
+            "hook_script": str(hook_path),
+            "config_file": str(root / ("lefthook.yml" if manager == "lefthook" else "")),
+            "used_existing_lefthook": has_lefthook,
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/flux-setup/SKILL.md
+++ b/skills/flux-setup/SKILL.md
@@ -41,6 +41,7 @@ $FLUXCTL session-phase set idle
   - **Lefthook** — fast pre-commit hooks
   - **Agent Browser** — checklist-driven browser QA with snapshots and screenshots
   - **Expect** — diff-driven browser QA, AI generates test plans from git changes
+  - **React Doctor** — React code health scan with an opt-in pre-commit gate for changed files
   - **CLI Continues** — resume/switch session context across agent CLIs
 - **Optional** recommended desktop apps (OS-aware prompts in setup):
   - **Superset** — primary orchestrator for parallel Codex sessions and cross-lab review worktrees
@@ -74,7 +75,7 @@ A step completion checklist and verification gate at the end of workflow.md will
 - Copies scripts (not symlinks) for portability across environments
 - Safe to re-run - will detect existing setup and offer to update
 - All MCPs and project state install project-local (`.mcp.json`, `.flux/`, `.flux/brain/`). Supported skill installs now go into PlaTo's `.secureskills/` store, with loose `.codex/skills/` / `.claude/skills/` folders retained only as compatibility fallbacks when needed
-- React-only skills should only be offered when the repo actually uses React or a React-based framework
+- React-only tools and skills should only be offered when the repo actually uses React or a React-based framework
 - After setup + restart, run `/flux:prime` first before feature work
 - After implementation/review, run `/flux:reflect` at session end
 

--- a/skills/flux-setup/templates/claude-md-snippet.md
+++ b/skills/flux-setup/templates/claude-md-snippet.md
@@ -137,6 +137,7 @@ This project uses Flux for structured AI development. Use `.flux/bin/fluxctl` in
 - If `.flux/context/agentmap.yaml` exists, use it as a fast structural overview of the repo before broad file exploration
 - Treat the agentmap as navigation aid only. Still read the actual files before making changes
 - If the `fff` MCP is available, prefer its tools for file search operations instead of default Glob/find — it's faster, supports fuzzy matching, and ranks by access frecency
+- In Flux quality/review passes for React repos, run `react-doctor` on the current diff when available. Prefer an installed `react-doctor` binary; otherwise use `npx -y react-doctor@latest . --diff HEAD --fail-on error`. This complements `/flux:dejank`; it does not replace the jank-specific workflow.
 
 <important if="you are troubleshooting Flux commands or encountering errors">
 **Troubleshooting:**

--- a/skills/flux-setup/workflow.md
+++ b/skills/flux-setup/workflow.md
@@ -722,6 +722,7 @@ Store for summary:
 Flux recommends CLI tools that complement the AI development workflow.
 
 **Note:** This step uses `OS_TYPE` detected in Step 4c. CLI tools work on all platforms.
+React Doctor is React-only. Only offer it when the repo uses React or a React-based framework. Selecting it should also wire an opt-in pre-commit hook so bad React changes are blocked before commit.
 
 ### Available CLI Tools
 
@@ -741,11 +742,28 @@ Flux recommends CLI tools that complement the AI development workflow.
 | `lefthook` | Lefthook | **Fast pre-commit hooks** — catch issues before CI | Yes | `npm i -g lefthook` | `npm i -g lefthook` | `npm i -g lefthook` |
 | `agent-browser` | Agent Browser | **Checklist-driven browser QA** — step-by-step UI automation with snapshots and screenshots | Yes | `npm i -g agent-browser` | `npm i -g agent-browser` | `npm i -g agent-browser` |
 | `expect-cli` | Expect | **Diff-driven browser QA** — AI generates test plans from git changes and runs them in a real browser | Yes | `npm i -g expect-cli` | `npm i -g expect-cli` | `npm i -g expect-cli` |
+| `react-doctor` | React Doctor | **React pre-commit health gate** — diff-scoped React diagnostics before commit and during review | Yes | `npm i -g react-doctor@latest` | `npm i -g react-doctor@latest` | `npm i -g react-doctor@latest` |
 | `cli-continues` | CLI Continues | **Session handoff between agents** — resume context across tools | Yes | `npm i -g continues` | `npm i -g continues` | `npm i -g continues` |
 | `plato` | PlaTo (`secureskills`) | **Secure skill installs** — signs and verifies project-local skills before agent runtime exposure | Yes | `"$PLUGIN_ROOT/scripts/install-plato.sh" stable codex` | `"$PLUGIN_ROOT/scripts/install-plato.sh" stable codex` | `"$PLUGIN_ROOT/scripts/install-plato.sh" stable codex` |
 ### Detect existing tools
 
 ```bash
+IS_REACT_BASED=0
+PACKAGE_FILES=$(
+  if command -v rg >/dev/null 2>&1; then
+    rg --files -g 'package.json' -g '!**/node_modules/**' .
+  else
+    find . -name package.json -not -path '*/node_modules/*'
+  fi
+)
+for pkg in $PACKAGE_FILES; do
+  REPO_DEPS=$(jq -r '((.dependencies // {}) + (.devDependencies // {})) | keys[]?' "$pkg" 2>/dev/null || true)
+  if echo "$REPO_DEPS" | grep -Eq '^(react|react-dom|next|@remix-run/react|react-router|react-router-dom|gatsby|expo|react-native|@vitejs/plugin-react|@vitejs/plugin-react-swc)$'; then
+    IS_REACT_BASED=1
+    break
+  fi
+done
+
 # Check if tools already installed
 HAVE_GH_CLI=$(which gh >/dev/null 2>&1 && echo 1 || echo 0)
 HAVE_JQ_CLI=$(which jq >/dev/null 2>&1 && echo 1 || echo 0)
@@ -753,6 +771,7 @@ HAVE_FZF_CLI=$(which fzf >/dev/null 2>&1 && echo 1 || echo 0)
 HAVE_LEFTHOOK_CLI=$(which lefthook >/dev/null 2>&1 && echo 1 || echo 0)
 HAVE_AGENT_BROWSER_CLI=$(which agent-browser >/dev/null 2>&1 && echo 1 || echo 0)
 HAVE_EXPECT_CLI=$(which expect-cli >/dev/null 2>&1 && echo 1 || echo 0)
+HAVE_REACT_DOCTOR_CLI=$(which react-doctor >/dev/null 2>&1 && echo 1 || echo 0)
 HAVE_CONTINUES_CLI=$( (which continues >/dev/null 2>&1 || which cont >/dev/null 2>&1) && echo 1 || echo 0)
 HAVE_PLATO_CLI=$(which secureskills >/dev/null 2>&1 && echo 1 || echo 0)
 HAVE_NPM=$(which npm >/dev/null 2>&1 && echo 1 || echo 0)
@@ -769,6 +788,7 @@ Build recommendations by platform so users only see installable options for thei
 - macOS: recommend brew-based tools plus npm-based tools when `npm` exists
 - Windows: recommend winget-based tools when `winget` exists, plus npm-based tools when `npm` exists
 - If `npm` is missing, do not offer npm-only tools and print: `Install Node.js first: https://nodejs.org`
+- If `IS_REACT_BASED=0`, do **not** offer React Doctor. Mention why: `React-based framework not detected, so Flux will skip offering React Doctor during setup.`
 
 Only show tools not already installed:
 
@@ -792,6 +812,7 @@ INSTALL_FZF=0
 INSTALL_LEFTHOOK=0
 INSTALL_AGENT_BROWSER=0
 INSTALL_EXPECT_CLI=0
+INSTALL_REACT_DOCTOR=0
 INSTALL_CONTINUES=0
 INSTALL_PLATO=0
 
@@ -806,6 +827,7 @@ INSTALL_PLATO=0
 {"label": "Lefthook", "description": "Fast pre-commit hooks to catch issues before CI (free)"}
 {"label": "Agent Browser", "description": "Checklist-driven browser QA — step-by-step automation with snapshots and screenshots (free)"}
 {"label": "Expect", "description": "Diff-driven browser QA — AI generates test plans from git changes, runs in real browser (free)"}
+{"label": "React Doctor", "description": "React-only pre-commit + review gate for changed files (free)"}
 {"label": "CLI Continues", "description": "Resume/switch coding session context across agent CLIs (free)"}
 {"label": "PlaTo", "description": "Secure project-local skill installs for Codex and Claude via secureskills (free)"}
 ```
@@ -921,11 +943,47 @@ if which npm >/dev/null 2>&1; then
   [ "$INSTALL_LEFTHOOK" = "1" ] && npm i -g lefthook 2>/dev/null || true
   [ "$INSTALL_AGENT_BROWSER" = "1" ] && npm i -g agent-browser 2>/dev/null || true
   [ "$INSTALL_EXPECT_CLI" = "1" ] && npm i -g expect-cli 2>/dev/null || true
+  [ "$INSTALL_REACT_DOCTOR" = "1" ] && npm i -g react-doctor@latest 2>/dev/null || true
   [ "$INSTALL_CONTINUES" = "1" ] && npm i -g continues 2>/dev/null || true
   [ "$INSTALL_PLATO" = "1" ] && "$PLUGIN_ROOT/scripts/install-plato.sh" stable codex 2>/dev/null || true
 else
   echo "npm not found. Install Node.js first: https://nodejs.org"
 fi
+```
+
+### React Doctor pre-commit hook
+
+If React Doctor was selected, wire it into a pre-commit hook immediately. This is the whole point of offering it during setup: React repos should fail fast before bad code reaches the branch.
+
+Use the helper script so the install is idempotent and deterministic:
+
+```bash
+REACT_DOCTOR_HOOK_STATUS="skipped"
+REACT_DOCTOR_HOOK_MANAGER="none"
+
+if [ "$INSTALL_REACT_DOCTOR" = "1" ]; then
+  HOOK_JSON=$(python3 "$PLUGIN_ROOT/scripts/install-react-doctor-hook.py" . 2>/dev/null || echo '{"success":false,"hook_status":"failed","manager":"none"}')
+  REACT_DOCTOR_HOOK_STATUS=$(echo "$HOOK_JSON" | jq -r '.hook_status // "failed"')
+  REACT_DOCTOR_HOOK_MANAGER=$(echo "$HOOK_JSON" | jq -r '.manager // "none"')
+fi
+```
+
+Hook behavior:
+- If Husky already exists, append the React Doctor runner to `.husky/pre-commit`
+- Else if Lefthook exists, merge a `react-doctor` command into `lefthook.yml`
+- Else create `lefthook.yml` and install Lefthook hooks
+- If Lefthook cannot be activated, fall back to `.git/hooks/pre-commit` for the current clone without deleting existing hook content; append the Flux runner instead
+
+The generated hook script should run only when staged files include `js/jsx/ts/tsx`, and should execute:
+
+```bash
+react-doctor . --diff HEAD --fail-on error
+```
+
+If the binary is unavailable, the hook may fall back to:
+
+```bash
+npx -y react-doctor@latest . --diff HEAD --fail-on error
 ```
 
 ### Browser QA preference
@@ -1003,12 +1061,20 @@ Detect whether this repo is React-based before building the skill menu:
 
 ```bash
 IS_REACT_BASED=0
-if [ -f "package.json" ]; then
-  REPO_DEPS=$(jq -r '((.dependencies // {}) + (.devDependencies // {})) | keys[]' package.json 2>/dev/null || true)
+PACKAGE_FILES=$(
+  if command -v rg >/dev/null 2>&1; then
+    rg --files -g 'package.json' -g '!**/node_modules/**' .
+  else
+    find . -name package.json -not -path '*/node_modules/*'
+  fi
+)
+for pkg in $PACKAGE_FILES; do
+  REPO_DEPS=$(jq -r '((.dependencies // {}) + (.devDependencies // {})) | keys[]?' "$pkg" 2>/dev/null || true)
   if echo "$REPO_DEPS" | grep -Eq '^(react|react-dom|next|@remix-run/react|react-router|react-router-dom|gatsby|expo|react-native|@vitejs/plugin-react|@vitejs/plugin-react-swc)$'; then
     IS_REACT_BASED=1
+    break
   fi
-fi
+done
 ```
 
 ```bash
@@ -2345,6 +2411,8 @@ CLI tools:
 - Lefthook: <installed | already installed | skipped>
 - Agent Browser: <installed | already installed | skipped>
 - Expect: <installed | already installed | skipped>
+- React Doctor: <installed | already installed | skipped | not offered (non-React repo)>
+- React Doctor pre-commit hook: <configured via lefthook | configured via husky | configured via git-hooks | already configured | skipped | failed>
 - CLI Continues: <installed | already installed | skipped>
 - Diffity: <installed | already installed | skipped | not offered>
 - Browser QA preference: <agent-browser | expect | not set>

--- a/skills/flux-work/phases.md
+++ b/skills/flux-work/phases.md
@@ -409,6 +409,7 @@ After all tasks complete (or periodically for large epics):
 
 - Run relevant tests
 - Run lint/format per repo. If the repo uses `lintcn`, include `npx lintcn lint` in this quality pass.
+- If the repo is React-based and the epic changed React UI code, run React Doctor on the current diff as a backstop even if the pre-commit hook already ran. Prefer an installed binary: `react-doctor . --diff HEAD --fail-on error`; otherwise use `npx -y react-doctor@latest . --diff HEAD --fail-on error`.
 - If change is large/risky, run the quality auditor subagent:
   - Task flux:quality-auditor("Review recent changes")
 - Fix critical issues

--- a/tests/scripts.test.ts
+++ b/tests/scripts.test.ts
@@ -7,7 +7,7 @@
 
 import { test, expect, describe, beforeAll } from 'bun:test'
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync, chmodSync, readFileSync } from 'fs'
-import { join } from 'path'
+import { dirname, join } from 'path'
 import { $ } from 'bun'
 
 // Resolve flux root from test file location (tests/ is inside flux/)
@@ -131,6 +131,25 @@ describe('Flux Scripts', () => {
         const parsed = JSON.parse(output)
 
         expect(parsed.installed.cli_tools).toContain('lintcn')
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true })
+      }
+    }, SCRIPT_TIMEOUT)
+
+    test('detects react-doctor when it is on PATH', async () => {
+      const tempDir = mkdtempSync(join(process.env.TMPDIR || '/tmp', 'flux-react-doctor-bin-'))
+      const doctorPath = join(tempDir, 'react-doctor')
+
+      try {
+        writeFileSync(doctorPath, '#!/bin/sh\nexit 0\n')
+        chmodSync(doctorPath, 0o755)
+
+        const output = await runScriptWithEnv('detect-installed.sh', [], FLUX_ROOT, {
+          PATH: `${tempDir}:${process.env.PATH || ''}`,
+        })
+        const parsed = JSON.parse(output)
+
+        expect(parsed.installed.cli_tools).toContain('react-doctor')
       } finally {
         rmSync(tempDir, { recursive: true, force: true })
       }
@@ -284,6 +303,73 @@ describe('Flux Scripts', () => {
       } catch (e) {
         expect(output).toBeTruthy()
       }
+    }, SCRIPT_TIMEOUT)
+  })
+
+  describe('install-react-doctor-hook.py', () => {
+
+    test('creates an idempotent React Doctor pre-commit hook setup', async () => {
+      const tmpRoot = `/tmp/flux-react-doctor-hook-${Date.now()}`
+      mkdirSync(tmpRoot, { recursive: true })
+      await $`git init ${tmpRoot}`.quiet()
+
+      const scriptPath = join(FLUX_ROOT, 'scripts', 'install-react-doctor-hook.py')
+      const env = {
+        ...process.env,
+        FLUX_SKIP_LEFTHOOK_INSTALL: '1',
+      }
+
+      const first = await $`python3 ${scriptPath} ${tmpRoot}`.env(env).text()
+      const firstParsed = JSON.parse(first)
+
+      expect(firstParsed.success).toBe(true)
+      expect(firstParsed.manager).toBe('lefthook')
+      expect(existsSync(join(tmpRoot, 'lefthook.yml'))).toBe(true)
+      expect(existsSync(join(tmpRoot, '.flux', 'hooks', 'react-doctor-pre-commit.sh'))).toBe(true)
+
+      const lefthookConfig = readFileSync(join(tmpRoot, 'lefthook.yml'), 'utf-8')
+      expect(lefthookConfig).toContain('react-doctor:')
+      expect(lefthookConfig).toContain('./.flux/hooks/react-doctor-pre-commit.sh')
+
+      const second = await $`python3 ${scriptPath} ${tmpRoot}`.env(env).text()
+      const secondParsed = JSON.parse(second)
+      const secondConfig = readFileSync(join(tmpRoot, 'lefthook.yml'), 'utf-8')
+
+      expect(secondParsed.success).toBe(true)
+      expect(secondConfig.match(/react-doctor:/g)?.length).toBe(1)
+
+      rmSync(tmpRoot, { recursive: true, force: true })
+    }, SCRIPT_TIMEOUT)
+
+    test('preserves an existing native pre-commit hook when falling back', async () => {
+      const tmpRoot = `/tmp/flux-react-doctor-native-hook-${Date.now()}`
+      mkdirSync(tmpRoot, { recursive: true })
+      await $`git init ${tmpRoot}`.quiet()
+
+      const gitHooksDir = join(tmpRoot, '.git', 'hooks')
+      mkdirSync(gitHooksDir, { recursive: true })
+      writeFileSync(
+        join(gitHooksDir, 'pre-commit'),
+        '#!/bin/sh\necho "existing native hook"\n',
+      )
+
+      const scriptPath = join(FLUX_ROOT, 'scripts', 'install-react-doctor-hook.py')
+      const gitPath = (await $`which git`.text()).trim()
+      const env = {
+        ...process.env,
+        PATH: dirname(gitPath),
+      }
+
+      const output = await $`python3 ${scriptPath} ${tmpRoot}`.env(env).text()
+      const parsed = JSON.parse(output)
+      const hookContents = readFileSync(join(gitHooksDir, 'pre-commit'), 'utf-8')
+
+      expect(parsed.success).toBe(true)
+      expect(parsed.manager).toBe('git-hooks')
+      expect(hookContents).toContain('existing native hook')
+      expect(hookContents).toContain('./.flux/hooks/react-doctor-pre-commit.sh')
+
+      rmSync(tmpRoot, { recursive: true, force: true })
     }, SCRIPT_TIMEOUT)
   })
 


### PR DESCRIPTION
## What React Doctor Is
React Doctor is a React-focused static analysis CLI. It scans a React codebase for correctness, performance, architecture, accessibility, and related health issues, and it supports diff-scoped runs so you can check only the files affected by the current change.

This PR integrates React Doctor into Flux as an opt-in preventive guardrail for React repos.

## Problem
Flux already had `Dejank` for symptom-driven React jank investigations, but it did not have a preventive React Doctor path in setup. React repos could not opt into installing `react-doctor` during `/flux:setup`, and selecting it did not wire a git hook to stop bad React changes before commit.

## What This PR Changes
- adds `react-doctor` to Flux's installed CLI detection
- offers React Doctor during `/flux:setup` only when the repo looks React-based
- upgrades React detection to scan project `package.json` files, not just the repo root, so monorepos are handled correctly
- installs a React Doctor pre-commit gate when the user selects it during setup
- keeps React Doctor in the quality pass as a backstop before submit
- updates setup docs, command docs, and generated agent instructions to reflect the workflow
- adds automated coverage for tool detection, hook installation, idempotency, and native-hook preservation

## Hook Strategy
The new hook installer prefers the repo's existing hook stack instead of forcing one:
- use Husky if the repo already has Husky
- otherwise use Lefthook if it exists
- otherwise create a Lefthook config and install hooks
- if Lefthook cannot be activated, append the Flux runner to the native `.git/hooks/pre-commit` hook instead of overwriting existing content

The generated hook script only runs when staged files include `js`, `jsx`, `ts`, or `tsx`, and executes React Doctor in diff mode:
- `react-doctor . --diff HEAD --fail-on error`
- falls back to `npx -y react-doctor@latest . --diff HEAD --fail-on error` when needed

## Why This Matters
This turns React Doctor into an actual preventive guardrail instead of a passive recommendation. In React repos, users can now opt into a setup path that blocks bad React changes before commit while still preserving Flux's later quality gate.

## Validation
- `bun test tests/scripts.test.ts`
