### PR TITLE
Require explicit entry gates and approval before Flux creates epics/tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Casual React jank complaints like "this flickers" or "the layout jumps" should a
 
 ### 3. Build
 
-After prime, just tell the agent what you want — *build a feature, fix a bug, refactor something, continue work*. Flux uses repo state plus your message to decide whether to scope, resume, review, or hand off.
+After prime, just tell the agent what you want — *build a feature, fix a bug, upgrade an existing feature, refactor something, continue work*. Flux uses repo state plus your message to decide whether to scope, resume, review, or hand off.
 
 > **Why keep Claude around at all?** Codex is Flux's primary driver for implementation, scouting, and day-to-day execution. Claude is optional and secondary: useful as the second lab in adversarial review, for cloud PR auto-fix, and for importing learnings from older transcript archives. During epic reviews, Flux runs dual-model review so two models with different training data review independently and consensus issues get auto-fixed. You can also bring your own review bot (Greptile, CodeRabbit) for a third perspective. See [Reviews](#reviews--two-tier-architecture) below.
 
@@ -168,8 +168,11 @@ flowchart TD
     RCA["RCA<br/>(root cause analysis)"]
     Dejank["Dejank<br/>(React jank audit)"]
     Remember["Remember<br/>(memory router)"]
+    ScopeStart["Scope Start<br/>(kind + audience<br/>+ depth + target)"]
     Scope["Scope<br/>(problem definition)"]
     StressTest{"Stress Test<br/>(assumption dialectic)"}
+    PlanApprove{"Approve Epic/Task<br/>Creation?"}
+    ApprovalWait["Await Developer<br/>Approval"]
     Work["Work<br/>(task loop)"]
     ImplReview["Impl Review<br/>(per-task, lightweight)"]
     EpicReview["Epic Review<br/>(per-epic, thorough)"]
@@ -187,24 +190,28 @@ flowchart TD
     Pulse -->|"new tools?<br/>nudge /flux:improve"| Prime
     Pulse -->|"all clear"| Prime
     Prime -->|"brain thin +<br/>past sessions exist"| Ruminate
-    Prime -->|"brain ready"| Scope
-    Ruminate -->|"bootstrap brain<br/>from history"| Scope
+    Prime -->|"brain ready"| ScopeStart
+    Ruminate -->|"bootstrap brain<br/>from history"| ScopeStart
     SessionStart -->|"remember / don't forget"| Remember
-    Remember -->|"stores to AGENTS.md<br/>or brain vault"| Scope
-    Scope -->|"non-technical user<br/>detected"| Propose
+    Remember -->|"stores to AGENTS.md<br/>or brain vault"| ScopeStart
+    ScopeStart -->|"non-technical user<br/>confirmed"| Propose
     Propose -->|"creates proposal PR<br/>for engineering"| ProposeDone["Proposal Created"]
-    Scope -->|"bug detected"| RCA
-    Scope -->|"React jank complaint +<br/>Dejank installed"| Dejank
+    ScopeStart -->|"bug confirmed"| RCA
+    ScopeStart -->|"React jank complaint +<br/>Dejank installed"| Dejank
     Dejank -->|"static scan or runtime<br/>investigation"| Scope
     RCA -->|"fix + regression test<br/>+ pitfall written"| Submit
+    ScopeStart -->|"workflow envelope<br/>confirmed"| Scope
     Scope -->|"ambiguous domain<br/>terms detected"| UbiqLang["Ubiquitous Language<br/>(glossary extraction)"]
     UbiqLang -->|"glossary written<br/>to brain vault"| StressTest
     Scope -->|"problem defined"| StressTest
     StressTest -->|"one-way door /<br/>UX assumption /<br/>deferred authority"| StressTestRun["Spawn Opposing<br/>Subagents"]
-    StressTest -->|"no tensions<br/>detected"| ExecChoice
-    StressTestRun -->|"synthesize +<br/>user decides"| ExecChoice{"Execute how?"}
+    StressTest -->|"no tensions<br/>detected"| PlanApprove
+    StressTestRun -->|"synthesize +<br/>user decides"| PlanApprove
     StressTest -->|"complex module<br/>boundary"| DesignInterface["Design Interface<br/>(parallel sub-agents)"]
-    DesignInterface -->|"interface chosen"| ExecChoice
+    DesignInterface -->|"interface chosen"| PlanApprove
+    PlanApprove -->|"approved"| ExecChoice{"Execute how?"}
+    PlanApprove -->|"not yet"| ApprovalWait
+    ApprovalWait -->|"developer approves"| ExecChoice
 
     ExecChoice -->|"task-by-task<br/>(interactive)"| Work
     ExecChoice -->|"ralph mode<br/>(autonomous)"| Ralph["Ralph<br/>(autonomous harness)"]
@@ -294,7 +301,7 @@ These utility skills run *inside* the owning phase rather than creating a new to
 | **Ruminate** | *Auto after Prime (conditional):* mines past session transcripts to bootstrap the brain vault. Triggers when brain has < 5 files and past sessions exist. | You've already taught the agent things in prior sessions — corrections, preferences, domain knowledge — but that knowledge dies with each session. Ruminate recovers it so you don't repeat yourself. Only runs once when the brain is empty. |
 | **Propose** | Stakeholder feature proposal: conversational planning with deep codebase investigation, honest time estimates, and engineering pushback — all presented in plain language a non-technical founder can skim. Supports Google Doc import. Updates business context automatically. | Non-technical team members describe features without implementation detail. Without Propose, vague requests go straight to engineering as ambiguous tickets — and "just remove credits" gets treated as a quick fix when it's actually a 2-week overhaul. Propose does a real technical investigation and gives honest estimates, so stakeholders understand the true cost before engineering time is spent. |
 | **RCA** | Bug-specific flow: backward trace from symptom to root cause, adversarial verification, regression test, embedded learnings. | Agents fix symptoms, not causes. They'll patch the crash without understanding why it crashed. RCA forces backward tracing from symptom → root cause, mandates regression tests, and writes a pitfall so the same class of bug is caught earlier next time. |
-| **Scope** | Double Diamond interview: classify work, surface blind spots, run a viability gate ("should we build this?"), stress-test assumptions, run a future-pressure pass for one-way doors and shared surfaces, then create an epic with sized tasks. After scoping, choose execution mode: **task-by-task** (interactive `/flux:work`) or **Ralph mode** (autonomous — runs all tasks + reviews unattended). | Agents start building the moment you describe a feature — they never say "this doesn't make sense" or "have you talked to users?" Without scoping, they miss edge cases, build the wrong thing, or validate bad ideas. The interview catches blind spots before a single line of code is written. The viability gate is the anti-sycophancy mechanism. The future-pressure pass is the anti-slop mechanism — it forces the plan to account for likely next features, failure modes, and reversal cost before the codebase calcifies around a prompt-local abstraction. |
+| **Scope** | Double Diamond interview: first make the workflow envelope explicit by confirming work kind (`feature` / `bug` / `upgrade` / `refactor`), audience (technical vs non-technical), depth (shallow vs deep), and implementation target; then surface blind spots, run a viability gate ("should we build this?"), stress-test assumptions, run a future-pressure pass for one-way doors and shared surfaces, and only create an epic/tasks after explicit approval. After scoping, choose execution mode: **task-by-task** (interactive `/flux:work`) or **Ralph mode** (autonomous — runs all tasks + reviews unattended). | Agents start building the moment you describe a feature — they never say "this doesn't make sense" or "have you talked to users?" Without scoping, they miss edge cases, build the wrong thing, or validate bad ideas. The interview catches blind spots before a single line of code is written. The viability gate is the anti-sycophancy mechanism. The future-pressure pass is the anti-slop mechanism — it forces the plan to account for likely next features, failure modes, and reversal cost before the codebase calcifies around a prompt-local abstraction. |
 | **Ubiquitous Language** | *Auto during Scope (conditional):* When ambiguous domain terms are detected during scoping, extracts a DDD-style glossary — picks canonical terms, flags ambiguities, lists aliases to avoid. Writes to `.flux/brain/business/glossary.md`. | Developers and domain experts use different words for the same concept. "Account" means one thing to support and another to engineering. Without a shared glossary, bugs hide in the translation. This catches terminological drift before it becomes architectural drift. |
 | **Design Interface** | *Auto during Scope (conditional):* When scoping identifies a complex module boundary or multiple viable interface approaches, spawns 3+ parallel sub-agents with different design constraints (minimize methods, maximize flexibility, optimize common case). Compares and recommends. Parallel fan-out should follow `flux-parallel-dispatch`. | Your first interface idea is rarely the best. "Design It Twice" (from *A Philosophy of Software Design*) ensures you see radically different approaches before committing to one. The parallel sub-agents prevent anchoring bias — each starts fresh with a different constraint. |
 | **Stress Test** | *Auto during Scope:* spawns two opposing subagents to argue both sides of detected tensions (architecture choices, UX assumptions, deferred authority). Synthesizes a recommendation that transforms the question — not compromise, reconceptualization. | Developers make one-way door decisions on autopilot — auth strategy, data model, API contracts — based on assumptions they haven't examined. "My senior said X" or "users probably want Y" become load-bearing beliefs that are expensive to reverse. The stress test catches these *before* any code is written, when changing direction costs nothing. Inspired by the [Electric Monks](https://github.com/KyleAMathews/hegelian-dialectic-skill) dialectic pattern. |
@@ -511,10 +518,10 @@ fluxctl config edit      # Open .flux/config.json in your editor
 |---------|-------------|-----------------|
 | `/flux:setup` | Initialize Flux in your project | 1. First time using Flux — scaffolds `.flux/`, configures preferences, installs tools |
 | `/flux:prime` | Codebase readiness audit (8 pillars, 48 criteria) | 2. After setup — Flux detects unprimed repos and prompts you. Runs once per repo |
-| `/flux:propose` | Stakeholder feature proposal with engineering pushback | 2.5. A non-technical teammate describes a feature — Flux interviews them, pushes back on complexity/cost, documents the proposal, and creates a PR for engineering handoff. Also detected implicitly during `/flux:scope` |
+| `/flux:propose` | Stakeholder proposal flow with engineering pushback | 2.5. A non-technical teammate describes a feature, bugfix request, or upgrade — Flux interviews them, pushes back on complexity/cost, documents the proposal, and creates a PR for engineering handoff. Also detected implicitly during `/flux:scope` and `/flux:plan` |
 | `/flux:rca` | Root cause analysis for bugs | 2.5. You paste an error or describe a bug — Flux traces backward to the root cause, verifies with adversarial review, writes the fix with regression test, and embeds learnings. Also detected implicitly during `/flux:scope` |
-| `/flux:scope <idea>` | Guided scoping workflow (`--deep`, `--explore N`) | 3. You say "build me a dashboard" — Flux interviews you, creates an epic with sized tasks |
-| `/flux:plan <idea>` | Create tasks only (skip interview) | 3. You already know exactly what to build — skip the Double Diamond interview, go straight to task creation |
+| `/flux:scope <idea>` | Guided scoping workflow (`--deep`, `--explore N`) | 3. You say "build me a dashboard" — Flux first confirms kind, audience, depth, and target, then interviews you and only creates an epic/tasks after approval |
+| `/flux:plan <idea>` | Create tasks only (skip interview) | 3. You already know exactly what to build — Flux still confirms the workflow envelope and asks whether shallow planning is enough or if you want deep Double Diamond scoping first |
 | `/flux:work <task>` | Execute task with context reload | 4. After scoping — spawns a worker per task, each re-anchors from brain vault before implementing |
 | `/flux:impl-review` | Lightweight per-task review (single model) | 5. Auto-triggered after each task completes inside `/flux:work` — you don't call this manually |
 | `/flux:epic-review <epic>` | Thorough epic review (adversarial + BYORB + browser QA + learning + desloppify) | 6. Auto-triggered when all tasks in an epic are done — runs the full review pipeline before shipping |

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Codex CLI](https://img.shields.io/badge/Codex_CLI-Primary-10A37F)](https://github.com/openai/codex)
 
-**The missing (self-improving) harness for Coding Agents.**<br>
+**The missing (self-improving) harness for Codex CLI.**<br>
 Build software reliably.
 
-> Recommended orchestrator: [SuperSet](https://superset.sh/) — parallel Codex/ClaudeCode sessions with git worktree isolation.
+> Recommended orchestrator: [SuperSet](https://superset.sh/) — parallel Codex sessions with git worktree isolation.
 
 </div>
 

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -100,9 +100,10 @@ Also detected **implicitly** — if someone uses `/flux:scope` with bug signals 
 **Recommended starting point.** Runs Flux's Product OS-style scoping workflow:
 
 1. **Start**
-   - classify feature, bug, or refactor
-   - choose shallow vs deep
-   - capture technical level and implementation target
+   - classify feature, bug, upgrade, or refactor
+   - explicitly confirm technical vs non-technical
+   - explicitly choose shallow vs deep
+   - capture implementation target
 2. **Discover / Define**
    - clarify the actual problem before solutioning
 3. **Develop / Deliver / Handoff**
@@ -116,7 +117,7 @@ Also detected **implicitly** — if someone uses `/flux:scope` with bug signals 
 /flux:scope Add user notifications --deep    # Deep mode (~45 min)
 ```
 
-Use `--deep` for high-stakes or ambiguous features.
+Use `--deep` for high-stakes or ambiguous work. If the user is non-technical, Flux should route into `/flux:propose` instead of continuing straight through technical scoping.
 
 ### /flux:setup
 
@@ -136,7 +137,7 @@ Initializes Flux in your project. Creates `.flux/`, the canonical brain vault at
 <p><em>Coming soon</em></p>
 </details>
 
-Breaks down an idea into atomic tasks with dependencies and acceptance criteria.
+Breaks down an idea into atomic tasks with dependencies and acceptance criteria. Flux still confirms the workflow envelope first, and if the user wants deep Double Diamond scoping instead of shallow direct planning, it should route to `/flux:scope --deep`.
 
 ### /flux:work
 

--- a/docs/fluxctl.md
+++ b/docs/fluxctl.md
@@ -77,8 +77,10 @@ Output:
 Create new epic.
 
 ```bash
-fluxctl epic create --title "Epic title" [--branch "fn-1-epic-title"] [--json]
+fluxctl epic create --title "Epic title" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" [--branch "fn-1-epic-title"] [--json]
 ```
+
+Creation is blocked unless the approval phrase is supplied via `--approve` or the `FLUX_CREATE_APPROVAL` environment variable.
 
 Output:
 ```json
@@ -147,7 +149,7 @@ Format: `backend:model` where backend is a CLI name and model is backend-specifi
 Create task under epic.
 
 ```bash
-fluxctl task create --epic fn-1 --title "Task title" [--deps fn-1.2,fn-1.3] [--acceptance-file accept.md] [--priority 10] [--json]
+fluxctl task create --epic fn-1 --title "Task title" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" [--deps fn-1.2,fn-1.3] [--acceptance-file accept.md] [--priority 10] [--json]
 ```
 
 Output:

--- a/docs/fluxctl.md
+++ b/docs/fluxctl.md
@@ -80,7 +80,7 @@ Create new epic.
 fluxctl epic create --title "Epic title" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" [--branch "fn-1-epic-title"] [--json]
 ```
 
-Creation is blocked unless the approval phrase is supplied via `--approve` or the `FLUX_CREATE_APPROVAL` environment variable.
+Creation is blocked unless the approval phrase is supplied via `--approve`.
 
 Output:
 ```json

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -147,7 +147,7 @@ RECOMMENDATION PULSE (recommendation_pulse)
   │                                            │
   │                  ┌─────────────────────────┤
   │                  │                         │
-  │           [stakeholder?]            [bug signals?]
+  │       [confirm audience]            [bug signals?]
   │             │ yes                      │ yes
   │             ▼                          ▼
   │        /flux:propose             ASK: RCA?
@@ -161,6 +161,10 @@ RECOMMENDATION PULSE (recommendation_pulse)
   │                  ┌──────────────────────────┘
   │                  ▼
   │             /flux:scope (scoping)
+  │                  │
+  │                  ▼
+  │      [START gate: confirm kind / audience /
+  │       depth / implementation target]
   │                  │
   │                  ▼
   │           [viability gate — 2+ red flags?]
@@ -336,7 +340,7 @@ The following routing happens when a user provides natural language instead of a
 | Codebase-understanding signals ("how does X work", "walk me through Y", "help me understand Z", "show me what touches X") and `diffity-tour` is installed | `/diffity-tour` | 3 |
 | Bug signals (error messages, "broken", stack traces) | `/flux:rca` (after confirmation) | 4 |
 | "remember X" / "don't forget X" / "keep in mind X" / "from now on X" | `/flux:remember` | 5 |
-| Feature/refactor description | `/flux:scope` | 6 |
+| Feature/upgrade/refactor description | `/flux:scope` | 6 |
 | Flow ID pattern (`fn-N-slug` or `fn-N`) | `/flux:work` (epic) | 7 |
 | Flow task ID pattern (`fn-N-slug.M` or `fn-N.M`) | `/flux:work` (single task) | 7 |
 | "improve X" / "help me find tools for X" / "optimize my workflow for X" | `/flux:improve` (with context) | 8 |
@@ -364,9 +368,12 @@ Skills can route to other skills during execution:
 | From | Condition | Routes To |
 |------|-----------|-----------|
 | `/flux:scope` | Stakeholder detected (3+ signals, 0 engineer signals) | `/flux:propose` |
+| `/flux:scope` | User explicitly confirms they are non-technical / stakeholder during the START gate | `/flux:propose` |
 | `/flux:scope` | React visual-jank signals + `dejank` installed + user confirms | `/flux:dejank` |
 | `/flux:scope` | User is trying to understand an existing feature/codepath + `diffity-tour` installed + no change request yet | `/diffity-tour` |
 | `/flux:scope` | Bug signals detected + user confirms | `/flux:rca` |
+| `/flux:plan` | User explicitly confirms they are non-technical / stakeholder during plan preflight | `/flux:propose` |
+| `/flux:plan` | User asks for deep Double Diamond before planning | `/flux:scope --deep` |
 | `/flux:scope` | "remember X" detected | `/flux:remember` |
 | `/flux:scope` | `--explore` flag | Explore mode (internal) |
 | `/flux:scope` | Stress test signals detected | Dialectic subagents (internal) |
@@ -396,11 +403,13 @@ These prevent invalid transitions:
 | Guard | Blocks | Requires |
 |-------|--------|----------|
 | Prime not done | All skills except `prime`, `setup`, `status`, `upgrade` | Run `/flux:prime` first |
+| Workflow envelope not explicit | Scope/plan progression beyond START or plan preflight | Confirm objective kind, audience, planning depth, and target |
 | No active epic | `/flux:work` without ID | Provide epic/task ID or run `/flux:scope` |
 | Tasks not created | `/flux:work <epic>` | Epic must have tasks |
 | Dependencies not met | `fluxctl start <task>` | All dependency tasks must be `done` |
 | Review not passed | Epic close | `completion_review_status == ship` |
 | Quality not passed | Submit | Tests pass, repo lint/format gates pass |
+| Explicit creation approval missing | `epic create` / `task create` | Developer approval phrase via `--approve` |
 
 ---
 
@@ -501,6 +510,7 @@ Override with `.flux/config.json`:
 | Session start hook | Every session | **Automatic** — injects brain vault index + workflow state |
 | Recommendation pulse | Every session (rate-limited 1x/day) | **Automatic** — nudges for new tools, brain vault health |
 | `session-state` routing | Before any work-like request | **Automatic** — routes to prime/scope/work/review |
+| Workflow envelope gate | Start of `/flux:scope` and natural-language `/flux:plan` | **Manual** — explicitly confirm kind, audience, depth, and target before deeper planning |
 | Stress test | During scope, if one-way door / UX assumption / deferred authority | **Automatic** — spawns opposing subagents |
 | Parallel dispatch utility | During Prime scouts or Scope explore fan-out | **Automatic within owning phase** — uses `flux-parallel-dispatch` to keep parallel work isolated |
 | Future pressure | During scope/plan, always quick; deeper for one-way doors/shared surfaces | **Automatic** — forecasts follow-on features, failure modes, observability, and reversal path |
@@ -521,6 +531,20 @@ Override with `.flux/config.json`:
 | Autofix | After PR submit, if `autofix.enabled: true` | **Automatic** (config-driven, non-blocking) |
 | Gate | Validate staging after merge | **Manual** (or CI auto) |
 | Upgrade | Get latest Flux version | **Manual** |
+
+---
+
+## Scope And Plan Entry Gates
+
+These are mandatory sub-states inside `scoping` and planning preflight even though they do not appear as top-level session states:
+
+1. **Classify the work** — `feature`, `bug`, `upgrade`, or `refactor`
+2. **Confirm audience** — technical implementer vs non-technical stakeholder
+3. **Confirm planning depth** — shallow vs deep Double Diamond
+4. **Confirm implementation target** — self with AI vs engineer handoff
+5. **Confirm persistence** — explicit approval before any epic/task creation
+
+Agents may use heuristics to suggest defaults, but they must not silently skip these confirmations on a fresh objective.
 
 ---
 

--- a/scripts/ci_test.sh
+++ b/scripts/ci_test.sh
@@ -62,6 +62,7 @@ git config user.email "ci@test.local"
 git config user.name "CI Test"
 
 cp "$PLUGIN_ROOT/scripts/fluxctl.py" scripts/
+cp -R "$PLUGIN_ROOT/scripts/fluxctl_pkg" scripts/
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 1. Basic Commands
@@ -69,6 +70,18 @@ cp "$PLUGIN_ROOT/scripts/fluxctl.py" scripts/
 echo -e "\n${YELLOW}--- Basic Commands ---${NC}"
 
 fluxctl init --json >/dev/null && pass "init" || fail "init"
+
+set +e
+NO_APPROVAL_JSON="$(fluxctl epic create --title "Needs approval" --json 2>&1)"
+NO_APPROVAL_RC=$?
+set -e
+if [[ "$NO_APPROVAL_RC" -ne 0 ]] && echo "$NO_APPROVAL_JSON" | grep -q "requires explicit developer approval"; then
+  pass "epic create requires approval"
+else
+  fail "epic create requires approval"
+fi
+
+export FLUX_CREATE_APPROVAL="I_APPROVE_CREATING_EPICS_AND_TASKS"
 
 EPIC_JSON="$(fluxctl epic create --title "Test Epic" --json)"
 EPIC_ID="$("$PYTHON_BIN" -c "import json,sys; print(json.load(sys.stdin)['id'])" <<< "$EPIC_JSON")"

--- a/scripts/ci_test.sh
+++ b/scripts/ci_test.sh
@@ -81,17 +81,15 @@ else
   fail "epic create requires approval"
 fi
 
-export FLUX_CREATE_APPROVAL="I_APPROVE_CREATING_EPICS_AND_TASKS"
-
-EPIC_JSON="$(fluxctl epic create --title "Test Epic" --json)"
+EPIC_JSON="$(fluxctl epic create --title "Test Epic" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json)"
 EPIC_ID="$("$PYTHON_BIN" -c "import json,sys; print(json.load(sys.stdin)['id'])" <<< "$EPIC_JSON")"
 [[ -n "$EPIC_ID" ]] && pass "epic create ($EPIC_ID)" || fail "epic create"
 
-TASK1_JSON="$(fluxctl task create --epic "$EPIC_ID" --title "Task One" --priority 2 --json)"
+TASK1_JSON="$(fluxctl task create --epic "$EPIC_ID" --title "Task One" --priority 2 --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json)"
 TASK1_ID="$("$PYTHON_BIN" -c "import json,sys; print(json.load(sys.stdin)['id'])" <<< "$TASK1_JSON")"
 [[ -n "$TASK1_ID" ]] && pass "task create ($TASK1_ID)" || fail "task create"
 
-TASK2_JSON="$(fluxctl task create --epic "$EPIC_ID" --title "Task Two" --priority 1 --json)"
+TASK2_JSON="$(fluxctl task create --epic "$EPIC_ID" --title "Task Two" --priority 1 --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json)"
 TASK2_ID="$("$PYTHON_BIN" -c "import json,sys; print(json.load(sys.stdin)['id'])" <<< "$TASK2_JSON")"
 
 fluxctl list --json >/dev/null && pass "list" || fail "list"
@@ -475,8 +473,8 @@ fluxctl ralph stop --run test-run >/dev/null
 rm -rf scripts/ralph/runs/test-run
 
 # Test task reset
-RESET_EPIC="$(fluxctl epic create --title "Reset test" --json | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
-RESET_TASK="$(fluxctl task create --epic "$RESET_EPIC" --title "Test task" --json | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+RESET_EPIC="$(fluxctl epic create --title "Reset test" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+RESET_TASK="$(fluxctl task create --epic "$RESET_EPIC" --title "Test task" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
 
 fluxctl start "$RESET_TASK" --json >/dev/null
 fluxctl done "$RESET_TASK" --json >/dev/null
@@ -493,8 +491,8 @@ set -e
 [[ $RESET_RC -ne 0 ]] && pass "task reset rejects in_progress" || fail "task reset should reject in_progress"
 
 # Test epic add-dep/rm-dep
-DEP_BASE="$(fluxctl epic create --title "Dep base" --json | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
-DEP_CHILD="$(fluxctl epic create --title "Dep child" --json | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+DEP_BASE="$(fluxctl epic create --title "Dep base" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+DEP_CHILD="$(fluxctl epic create --title "Dep child" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
 
 fluxctl epic add-dep "$DEP_CHILD" "$DEP_BASE" --json >/dev/null
 DEPS="$(fluxctl show "$DEP_CHILD" --json | "$PYTHON_BIN" -c 'import json,sys; print(",".join(json.load(sys.stdin).get("depends_on_epics",[])))')"
@@ -536,9 +534,9 @@ ACTIVE_COUNT="$(fluxctl status --json | "$PYTHON_BIN" -c 'import json,sys; d=jso
 rm -rf scripts/ralph/runs/completed-test
 
 # Test task reset --cascade
-CASCADE_EPIC="$(fluxctl epic create --title "Cascade test" --json | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
-CASCADE_T1="$(fluxctl task create --epic "$CASCADE_EPIC" --title "Base task" --json | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
-CASCADE_T2="$(fluxctl task create --epic "$CASCADE_EPIC" --title "Dependent task" --json | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+CASCADE_EPIC="$(fluxctl epic create --title "Cascade test" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+CASCADE_T1="$(fluxctl task create --epic "$CASCADE_EPIC" --title "Base task" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+CASCADE_T2="$(fluxctl task create --epic "$CASCADE_EPIC" --title "Dependent task" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
 fluxctl dep add "$CASCADE_T2" "$CASCADE_T1" --json >/dev/null  # T2 depends on T1
 fluxctl start "$CASCADE_T1" >/dev/null && fluxctl done "$CASCADE_T1" >/dev/null
 fluxctl start "$CASCADE_T2" >/dev/null && fluxctl done "$CASCADE_T2" >/dev/null

--- a/scripts/fluxctl_pkg/__main__.py
+++ b/scripts/fluxctl_pkg/__main__.py
@@ -3,6 +3,7 @@ import argparse
 from .utils import (
     EPIC_STATUS, TASK_STATUS, OBJECTIVE_KINDS, SCOPE_MODES,
     TECHNICAL_LEVELS, IMPLEMENTATION_TARGETS, WORKFLOW_STATUSES, PRIME_STATUSES,
+    CREATE_APPROVAL_PHRASE,
     SESSION_PHASES,
 )
 from .init import cmd_init, cmd_detect, cmd_status, cmd_state_path, cmd_agentmap, cmd_migrate_state
@@ -214,6 +215,10 @@ def main() -> None:
 
     p_epic_create = epic_sub.add_parser("create", help="Create new epic")
     p_epic_create.add_argument("--title", required=True, help="Epic title")
+    p_epic_create.add_argument(
+        "--approve",
+        help=f'Explicit approval phrase required for creation: "{CREATE_APPROVAL_PHRASE}"',
+    )
     p_epic_create.add_argument("--branch", help="Branch name to store on epic")
     p_epic_create.add_argument(
         "--kind",
@@ -374,6 +379,10 @@ def main() -> None:
     p_task_create = task_sub.add_parser("create", help="Create new task")
     p_task_create.add_argument("--epic", required=True, help="Epic ID (e.g., fn-1, fn-1-add-auth)")
     p_task_create.add_argument("--title", required=True, help="Task title")
+    p_task_create.add_argument(
+        "--approve",
+        help=f'Explicit approval phrase required for creation: "{CREATE_APPROVAL_PHRASE}"',
+    )
     p_task_create.add_argument("--deps", help="Comma-separated dependency IDs")
     p_task_create.add_argument(
         "--acceptance-file", help="Markdown file with acceptance criteria"

--- a/scripts/fluxctl_pkg/epics.py
+++ b/scripts/fluxctl_pkg/epics.py
@@ -42,6 +42,7 @@ from .utils import (
     parse_id,
     read_file_or_stdin,
     read_text_or_exit,
+    require_creation_approval,
     scan_max_epic_id,
     slugify,
     workflow_phases_for_mode,
@@ -467,6 +468,8 @@ TBD
 
 def cmd_epic_create(args: argparse.Namespace) -> None:
     """Create a new epic."""
+    require_creation_approval(args.approve, "Epic creation", use_json=args.json)
+
     if not ensure_flux_exists():
         error_exit(
             ".flux/ does not exist. Run 'fluxctl init' first.", use_json=args.json

--- a/scripts/fluxctl_pkg/epics.py
+++ b/scripts/fluxctl_pkg/epics.py
@@ -1829,7 +1829,7 @@ def cmd_session_state(args: argparse.Namespace) -> None:
             "task": None,
             "prime": prime_state,
             "architecture": architecture_state,
-            "message": "No open objective. Start a new feature, bug, or refactor scope.",
+            "message": "No open objective. Start a new feature, bug, upgrade, or refactor scope.",
             "next_action": next_action,
             "router": router_for(next_action, "fresh_session_no_objective"),
         }

--- a/scripts/fluxctl_pkg/tasks.py
+++ b/scripts/fluxctl_pkg/tasks.py
@@ -34,6 +34,7 @@ from .utils import (
     parse_id,
     read_file_or_stdin,
     read_text_or_exit,
+    require_creation_approval,
     require_keys,
     scan_max_task_id,
     task_priority,
@@ -262,6 +263,8 @@ def find_dependents(task_id: str, same_epic: bool = False) -> list[str]:
 
 def cmd_task_create(args: argparse.Namespace) -> None:
     """Create a new task under an epic."""
+    require_creation_approval(args.approve, "Task creation", use_json=args.json)
+
     if not ensure_flux_exists():
         error_exit(
             ".flux/ does not exist. Run 'fluxctl init' first.", use_json=args.json

--- a/scripts/fluxctl_pkg/utils.py
+++ b/scripts/fluxctl_pkg/utils.py
@@ -56,7 +56,6 @@ OBJECTIVE_KINDS = ["feature", "bug", "refactor"]
 SCOPE_MODES = ["shallow", "deep"]
 TECHNICAL_LEVELS = ["non_technical", "semi_technical", "technical"]
 IMPLEMENTATION_TARGETS = ["self_with_ai", "engineer_handoff"]
-CREATE_APPROVAL_ENV_VAR = "FLUX_CREATE_APPROVAL"
 CREATE_APPROVAL_PHRASE = "I_APPROVE_CREATING_EPICS_AND_TASKS"
 WORKFLOW_PHASES_DEEP = ["start", "discover", "define", "develop", "deliver", "handoff"]
 WORKFLOW_PHASES_SHALLOW = ["start", "discover", "define", "deliver", "handoff"]
@@ -210,14 +209,13 @@ def require_creation_approval(
     approval: Optional[str], action: str, *, use_json: bool = True
 ) -> str:
     """Require explicit developer approval before creating epics/tasks."""
-    candidate = (approval or os.environ.get(CREATE_APPROVAL_ENV_VAR) or "").strip()
+    candidate = (approval or "").strip()
     if candidate == CREATE_APPROVAL_PHRASE:
         return candidate
     quoted_phrase = shlex.quote(CREATE_APPROVAL_PHRASE)
     error_exit(
         f"{action} requires explicit developer approval. "
-        f"Re-run with --approve {quoted_phrase} after the developer approves, "
-        f"or export {CREATE_APPROVAL_ENV_VAR}={quoted_phrase} for this shell.",
+        f"Re-run with --approve {quoted_phrase} after the developer approves.",
         use_json=use_json,
     )
 

--- a/scripts/fluxctl_pkg/utils.py
+++ b/scripts/fluxctl_pkg/utils.py
@@ -52,7 +52,7 @@ CONFIG_FILE = "config.json"
 
 EPIC_STATUS = ["open", "done"]
 TASK_STATUS = ["todo", "in_progress", "blocked", "done"]
-OBJECTIVE_KINDS = ["feature", "bug", "refactor"]
+OBJECTIVE_KINDS = ["feature", "bug", "upgrade", "refactor"]
 SCOPE_MODES = ["shallow", "deep"]
 TECHNICAL_LEVELS = ["non_technical", "semi_technical", "technical"]
 IMPLEMENTATION_TARGETS = ["self_with_ai", "engineer_handoff"]

--- a/scripts/fluxctl_pkg/utils.py
+++ b/scripts/fluxctl_pkg/utils.py
@@ -56,6 +56,8 @@ OBJECTIVE_KINDS = ["feature", "bug", "refactor"]
 SCOPE_MODES = ["shallow", "deep"]
 TECHNICAL_LEVELS = ["non_technical", "semi_technical", "technical"]
 IMPLEMENTATION_TARGETS = ["self_with_ai", "engineer_handoff"]
+CREATE_APPROVAL_ENV_VAR = "FLUX_CREATE_APPROVAL"
+CREATE_APPROVAL_PHRASE = "I_APPROVE_CREATING_EPICS_AND_TASKS"
 WORKFLOW_PHASES_DEEP = ["start", "discover", "define", "develop", "deliver", "handoff"]
 WORKFLOW_PHASES_SHALLOW = ["start", "discover", "define", "deliver", "handoff"]
 WORKFLOW_STATUSES = [
@@ -202,6 +204,22 @@ def error_exit(message: str, code: int = 1, use_json: bool = True) -> None:
     else:
         print(f"Error: {message}", file=sys.stderr)
     sys.exit(code)
+
+
+def require_creation_approval(
+    approval: Optional[str], action: str, *, use_json: bool = True
+) -> str:
+    """Require explicit developer approval before creating epics/tasks."""
+    candidate = (approval or os.environ.get(CREATE_APPROVAL_ENV_VAR) or "").strip()
+    if candidate == CREATE_APPROVAL_PHRASE:
+        return candidate
+    quoted_phrase = shlex.quote(CREATE_APPROVAL_PHRASE)
+    error_exit(
+        f"{action} requires explicit developer approval. "
+        f"Re-run with --approve {quoted_phrase} after the developer approves, "
+        f"or export {CREATE_APPROVAL_ENV_VAR}={quoted_phrase} for this shell.",
+        use_json=use_json,
+    )
 
 
 def now_iso() -> str:

--- a/scripts/plan_review_prompt_smoke.sh
+++ b/scripts/plan_review_prompt_smoke.sh
@@ -13,6 +13,7 @@ fi
 TEST_DIR="${TEST_DIR:-/tmp/flux-plan-review-smoke-rp-$$}"
 CLAUDE_BIN="${CLAUDE_BIN:-claude}"
 EPIC_ID="${EPIC_ID:-fn-1}"
+export FLUX_CREATE_APPROVAL="I_APPROVE_CREATING_EPICS_AND_TASKS"
 
 fail() { echo "plan_review_prompt_smoke: $*" >&2; exit 1; }
 
@@ -60,6 +61,7 @@ git commit -m "chore: init" >/dev/null
 mkdir -p scripts/ralph
 cp "$PLUGIN_ROOT/scripts/fluxctl.py" scripts/ralph/fluxctl.py
 cp "$PLUGIN_ROOT/scripts/fluxctl" scripts/ralph/fluxctl
+cp -R "$PLUGIN_ROOT/scripts/fluxctl_pkg" scripts/ralph/fluxctl_pkg
 chmod +x scripts/ralph/fluxctl
 
 FLUXCTL="scripts/ralph/fluxctl"

--- a/scripts/plan_review_prompt_smoke.sh
+++ b/scripts/plan_review_prompt_smoke.sh
@@ -13,7 +13,6 @@ fi
 TEST_DIR="${TEST_DIR:-/tmp/flux-plan-review-smoke-rp-$$}"
 CLAUDE_BIN="${CLAUDE_BIN:-claude}"
 EPIC_ID="${EPIC_ID:-fn-1}"
-export FLUX_CREATE_APPROVAL="I_APPROVE_CREATING_EPICS_AND_TASKS"
 
 fail() { echo "plan_review_prompt_smoke: $*" >&2; exit 1; }
 
@@ -66,7 +65,7 @@ chmod +x scripts/ralph/fluxctl
 
 FLUXCTL="scripts/ralph/fluxctl"
 $FLUXCTL init --json >/dev/null
-$FLUXCTL epic create --title "Tiny lib" --json >/dev/null
+$FLUXCTL epic create --title "Tiny lib" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
 
 cat > "$TEST_DIR/epic.md" <<'EOF'
 # fn-1 Tiny lib

--- a/scripts/ralph_e2e_rp_test.sh
+++ b/scripts/ralph_e2e_rp_test.sh
@@ -18,8 +18,6 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
-export FLUX_CREATE_APPROVAL="I_APPROVE_CREATING_EPICS_AND_TASKS"
-
 fail() { echo "ralph_e2e_rp: $*" >&2; exit 1; }
 
 run_with_timeout() {
@@ -196,8 +194,8 @@ cp "$PLUGIN_ROOT/skills/flux-setup/templates/usage.md" .flux/usage.md
 cat "$PLUGIN_ROOT/skills/flux-setup/templates/claude-md-snippet.md" > CLAUDE.md
 echo -e "${GREEN}✓${NC} Setup mirrored (.flux/bin/, usage.md, CLAUDE.md)"
 
-scripts/ralph/fluxctl epic create --title "Tiny lib" --json >/dev/null
-scripts/ralph/fluxctl epic create --title "Tiny follow-up" --json >/dev/null
+scripts/ralph/fluxctl epic create --title "Tiny lib" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
+scripts/ralph/fluxctl epic create --title "Tiny follow-up" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
 
 cat > "$TEST_DIR/epic.md" <<'EOF'
 # fn-1 Tiny lib
@@ -259,8 +257,8 @@ cat > "$TEST_DIR/accept.md" <<'EOF'
 - [ ] `npm test` passes (smoke only)
 EOF
 
-scripts/ralph/fluxctl task create --epic fn-1 --title "Add add() helper" --acceptance-file "$TEST_DIR/accept.md" --json >/dev/null
-scripts/ralph/fluxctl task create --epic fn-2 --title "Add tiny note" --acceptance-file "$TEST_DIR/accept.md" --json >/dev/null
+scripts/ralph/fluxctl task create --epic fn-1 --title "Add add() helper" --acceptance-file "$TEST_DIR/accept.md" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
+scripts/ralph/fluxctl task create --epic fn-2 --title "Add tiny note" --acceptance-file "$TEST_DIR/accept.md" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
 
 mkdir -p "$TEST_DIR/bin"
 PLUGINS_DIR="$(dirname "$PLUGIN_ROOT")"

--- a/scripts/ralph_e2e_rp_test.sh
+++ b/scripts/ralph_e2e_rp_test.sh
@@ -18,6 +18,8 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
+export FLUX_CREATE_APPROVAL="I_APPROVE_CREATING_EPICS_AND_TASKS"
+
 fail() { echo "ralph_e2e_rp: $*" >&2; exit 1; }
 
 run_with_timeout() {
@@ -162,6 +164,7 @@ mkdir -p scripts/ralph
 cp -R "$PLUGIN_ROOT/skills/flux-ralph-init/templates/." scripts/ralph/
 cp "$PLUGIN_ROOT/scripts/fluxctl.py" scripts/ralph/fluxctl.py
 cp "$PLUGIN_ROOT/scripts/fluxctl" scripts/ralph/fluxctl
+cp -R "$PLUGIN_ROOT/scripts/fluxctl_pkg" scripts/ralph/fluxctl_pkg
 chmod +x scripts/ralph/ralph.sh scripts/ralph/ralph_once.sh scripts/ralph/fluxctl
 FLUXCTL="scripts/ralph/fluxctl"
 
@@ -187,6 +190,7 @@ scripts/ralph/fluxctl init --json >/dev/null
 mkdir -p .flux/bin
 cp "$PLUGIN_ROOT/scripts/fluxctl" .flux/bin/fluxctl
 cp "$PLUGIN_ROOT/scripts/fluxctl.py" .flux/bin/fluxctl.py
+cp -R "$PLUGIN_ROOT/scripts/fluxctl_pkg" .flux/bin/fluxctl_pkg
 chmod +x .flux/bin/fluxctl
 cp "$PLUGIN_ROOT/skills/flux-setup/templates/usage.md" .flux/usage.md
 cat "$PLUGIN_ROOT/skills/flux-setup/templates/claude-md-snippet.md" > CLAUDE.md

--- a/scripts/ralph_e2e_short_rp_test.sh
+++ b/scripts/ralph_e2e_short_rp_test.sh
@@ -20,6 +20,8 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
+export FLUX_CREATE_APPROVAL="I_APPROVE_CREATING_EPICS_AND_TASKS"
+
 fail() { echo "ralph_e2e_short: $*" >&2; exit 1; }
 
 cleanup() {
@@ -62,6 +64,7 @@ mkdir -p scripts/ralph
 cp -R "$PLUGIN_ROOT/skills/flux-ralph-init/templates/." scripts/ralph/
 cp "$PLUGIN_ROOT/scripts/fluxctl.py" scripts/ralph/fluxctl.py
 cp "$PLUGIN_ROOT/scripts/fluxctl" scripts/ralph/fluxctl
+cp -R "$PLUGIN_ROOT/scripts/fluxctl_pkg" scripts/ralph/fluxctl_pkg
 chmod +x scripts/ralph/ralph.sh scripts/ralph/ralph_once.sh scripts/ralph/fluxctl
 FLUXCTL="scripts/ralph/fluxctl"
 
@@ -86,6 +89,7 @@ scripts/ralph/fluxctl init --json >/dev/null
 mkdir -p .flux/bin
 cp "$PLUGIN_ROOT/scripts/fluxctl" .flux/bin/fluxctl
 cp "$PLUGIN_ROOT/scripts/fluxctl.py" .flux/bin/fluxctl.py
+cp -R "$PLUGIN_ROOT/scripts/fluxctl_pkg" .flux/bin/fluxctl_pkg
 chmod +x .flux/bin/fluxctl
 cp "$PLUGIN_ROOT/skills/flux-setup/templates/usage.md" .flux/usage.md
 cat "$PLUGIN_ROOT/skills/flux-setup/templates/claude-md-snippet.md" > CLAUDE.md

--- a/scripts/ralph_e2e_short_rp_test.sh
+++ b/scripts/ralph_e2e_short_rp_test.sh
@@ -20,8 +20,6 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
-export FLUX_CREATE_APPROVAL="I_APPROVE_CREATING_EPICS_AND_TASKS"
-
 fail() { echo "ralph_e2e_short: $*" >&2; exit 1; }
 
 cleanup() {
@@ -95,8 +93,8 @@ cp "$PLUGIN_ROOT/skills/flux-setup/templates/usage.md" .flux/usage.md
 cat "$PLUGIN_ROOT/skills/flux-setup/templates/claude-md-snippet.md" > CLAUDE.md
 echo -e "${GREEN}✓${NC} Setup mirrored"
 
-scripts/ralph/fluxctl epic create --title "Add function" --json >/dev/null
-scripts/ralph/fluxctl epic create --title "Add docs" --json >/dev/null
+scripts/ralph/fluxctl epic create --title "Add function" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
+scripts/ralph/fluxctl epic create --title "Add docs" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
 
 # MINIMAL epic spec - one clear deliverable, no room for task expansion
 cat > "$TEST_DIR/epic1.md" <<'EOF'
@@ -135,8 +133,8 @@ cat > "$TEST_DIR/accept2.md" <<'EOF'
 - [ ] README mentions "tiny math library"
 EOF
 
-scripts/ralph/fluxctl task create --epic fn-1 --title "Add add() function" --acceptance-file "$TEST_DIR/accept1.md" --json >/dev/null
-scripts/ralph/fluxctl task create --epic fn-2 --title "Add README note" --acceptance-file "$TEST_DIR/accept2.md" --json >/dev/null
+scripts/ralph/fluxctl task create --epic fn-1 --title "Add add() function" --acceptance-file "$TEST_DIR/accept1.md" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
+scripts/ralph/fluxctl task create --epic fn-2 --title "Add README note" --acceptance-file "$TEST_DIR/accept2.md" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
 
 mkdir -p "$TEST_DIR/bin"
 PLUGINS_DIR="$(dirname "$PLUGIN_ROOT")"

--- a/scripts/ralph_e2e_test.sh
+++ b/scripts/ralph_e2e_test.sh
@@ -19,6 +19,8 @@ YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m'
 
+export FLUX_CREATE_APPROVAL="I_APPROVE_CREATING_EPICS_AND_TASKS"
+
 fail() { echo "ralph_e2e: $*" >&2; exit 1; }
 
 cleanup() {
@@ -74,6 +76,7 @@ mkdir -p scripts/ralph
 cp -R "$PLUGIN_ROOT/skills/flux-ralph-init/templates/." scripts/ralph/
 cp "$PLUGIN_ROOT/scripts/fluxctl.py" scripts/ralph/fluxctl.py
 cp "$PLUGIN_ROOT/scripts/fluxctl" scripts/ralph/fluxctl
+cp -R "$PLUGIN_ROOT/scripts/fluxctl_pkg" scripts/ralph/fluxctl_pkg
 chmod +x scripts/ralph/ralph.sh scripts/ralph/ralph_once.sh scripts/ralph/fluxctl
 
 python3 - <<'PY'

--- a/scripts/ralph_e2e_test.sh
+++ b/scripts/ralph_e2e_test.sh
@@ -19,8 +19,6 @@ YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m'
 
-export FLUX_CREATE_APPROVAL="I_APPROVE_CREATING_EPICS_AND_TASKS"
-
 fail() { echo "ralph_e2e: $*" >&2; exit 1; }
 
 cleanup() {
@@ -96,8 +94,8 @@ cfg.write_text(text)
 PY
 
 scripts/ralph/fluxctl init --json >/dev/null
-scripts/ralph/fluxctl epic create --title "Tiny lib" --json >/dev/null
-scripts/ralph/fluxctl epic create --title "Tiny follow-up" --json >/dev/null
+scripts/ralph/fluxctl epic create --title "Tiny lib" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
+scripts/ralph/fluxctl epic create --title "Tiny follow-up" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
 
 cat > "$TEST_DIR/epic.md" <<'EOF'
 # fn-1 Tiny lib
@@ -131,8 +129,8 @@ cat > "$TEST_DIR/accept.md" <<'EOF'
 - [ ] Add README usage snippet
 EOF
 
-scripts/ralph/fluxctl task create --epic fn-1 --title "Add add() helper" --acceptance-file "$TEST_DIR/accept.md" --json >/dev/null
-scripts/ralph/fluxctl task create --epic fn-2 --title "Add tiny note" --acceptance-file "$TEST_DIR/accept.md" --json >/dev/null
+scripts/ralph/fluxctl task create --epic fn-1 --title "Add add() helper" --acceptance-file "$TEST_DIR/accept.md" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
+scripts/ralph/fluxctl task create --epic fn-2 --title "Add tiny note" --acceptance-file "$TEST_DIR/accept.md" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
 
 mkdir -p "$TEST_DIR/bin"
 PLUGINS_DIR="$(dirname "$PLUGIN_ROOT")"

--- a/scripts/ralph_smoke_rp.sh
+++ b/scripts/ralph_smoke_rp.sh
@@ -19,8 +19,6 @@ YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m'
 
-export FLUX_CREATE_APPROVAL="I_APPROVE_CREATING_EPICS_AND_TASKS"
-
 fail() { echo "ralph_smoke_rp: $*" >&2; exit 1; }
 
 run_with_timeout() {
@@ -178,7 +176,7 @@ cfg.write_text(text)
 PY
 
 scripts/ralph/fluxctl init --json >/dev/null
-scripts/ralph/fluxctl epic create --title "Tiny lib" --json >/dev/null
+scripts/ralph/fluxctl epic create --title "Tiny lib" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
 
 cat > "$TEST_DIR/epic.md" <<'EOF'
 # fn-1 Tiny lib
@@ -227,7 +225,7 @@ cat > "$TEST_DIR/accept.md" <<'EOF'
 - [ ] README notes TS tooling required
 EOF
 
-scripts/ralph/fluxctl task create --epic fn-1 --title "Add docs" --acceptance-file "$TEST_DIR/accept.md" --json >/dev/null
+scripts/ralph/fluxctl task create --epic fn-1 --title "Add docs" --acceptance-file "$TEST_DIR/accept.md" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
 
 mkdir -p "$TEST_DIR/bin"
 PLUGINS_DIR="$(dirname "$PLUGIN_ROOT")"

--- a/scripts/ralph_smoke_rp.sh
+++ b/scripts/ralph_smoke_rp.sh
@@ -19,6 +19,8 @@ YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m'
 
+export FLUX_CREATE_APPROVAL="I_APPROVE_CREATING_EPICS_AND_TASKS"
+
 fail() { echo "ralph_smoke_rp: $*" >&2; exit 1; }
 
 run_with_timeout() {
@@ -155,6 +157,7 @@ mkdir -p scripts/ralph
 cp -R "$PLUGIN_ROOT/skills/flux-ralph-init/templates/." scripts/ralph/
 cp "$PLUGIN_ROOT/scripts/fluxctl.py" scripts/ralph/fluxctl.py
 cp "$PLUGIN_ROOT/scripts/fluxctl" scripts/ralph/fluxctl
+cp -R "$PLUGIN_ROOT/scripts/fluxctl_pkg" scripts/ralph/fluxctl_pkg
 chmod +x scripts/ralph/ralph.sh scripts/ralph/ralph_once.sh scripts/ralph/fluxctl
 FLUXCTL="scripts/ralph/fluxctl"
 

--- a/scripts/ralph_smoke_test.sh
+++ b/scripts/ralph_smoke_test.sh
@@ -31,8 +31,6 @@ RED='\033[0;31m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
-export FLUX_CREATE_APPROVAL="I_APPROVE_CREATING_EPICS_AND_TASKS"
-
 cleanup() {
   rm -rf "$TEST_DIR"
 }
@@ -191,9 +189,9 @@ latest_run_dir() {
 }
 
 echo -e "${YELLOW}--- ralph_once ---${NC}"
-EPIC1_JSON="$(scripts/ralph/fluxctl epic create --title "Ralph Epic" --json)"
+EPIC1_JSON="$(scripts/ralph/fluxctl epic create --title "Ralph Epic" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json)"
 EPIC1="$(echo "$EPIC1_JSON" | extract_id)"
-scripts/ralph/fluxctl task create --epic "$EPIC1" --title "Ralph Task" --json >/dev/null
+scripts/ralph/fluxctl task create --epic "$EPIC1" --title "Ralph Task" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
 write_config "none" "none" "0" "new" "3" "5" "2"
 CLAUDE_BIN="$TEST_DIR/bin/claude" scripts/ralph/ralph_once.sh >/dev/null
 # Mark plan review done so it doesn't block later tests when REQUIRE_PLAN_REVIEW=1
@@ -202,11 +200,11 @@ echo -e "${GREEN}✓${NC} ralph_once runs"
 PASS=$((PASS + 1))
 
 echo -e "${YELLOW}--- ralph.sh completes epic ---${NC}"
-EPIC2_JSON="$(scripts/ralph/fluxctl epic create --title "Ralph Epic 2" --json)"
+EPIC2_JSON="$(scripts/ralph/fluxctl epic create --title "Ralph Epic 2" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json)"
 EPIC2="$(echo "$EPIC2_JSON" | extract_id)"
-TASK2_1_JSON="$(scripts/ralph/fluxctl task create --epic "$EPIC2" --title "Task 1" --json)"
+TASK2_1_JSON="$(scripts/ralph/fluxctl task create --epic "$EPIC2" --title "Task 1" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json)"
 TASK2_1="$(echo "$TASK2_1_JSON" | extract_id)"
-TASK2_2_JSON="$(scripts/ralph/fluxctl task create --epic "$EPIC2" --title "Task 2" --json)"
+TASK2_2_JSON="$(scripts/ralph/fluxctl task create --epic "$EPIC2" --title "Task 2" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json)"
 TASK2_2="$(echo "$TASK2_2_JSON" | extract_id)"
 # Use rp for both to test receipt generation (none skips receipts correctly via fix for #8)
 write_config "rp" "rp" "1" "new" "6" "5" "2"
@@ -261,9 +259,9 @@ else
 fi
 
 echo -e "${YELLOW}--- UI output verification ---${NC}"
-EPIC3_JSON="$(scripts/ralph/fluxctl epic create --title "UI Test Epic" --json)"
+EPIC3_JSON="$(scripts/ralph/fluxctl epic create --title "UI Test Epic" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json)"
 EPIC3="$(echo "$EPIC3_JSON" | extract_id)"
-scripts/ralph/fluxctl task create --epic "$EPIC3" --title "UI Test Task" --json >/dev/null
+scripts/ralph/fluxctl task create --epic "$EPIC3" --title "UI Test Task" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
 write_config "none" "none" "0" "new" "3" "5" "2"
 ui_output="$(STUB_MODE=success CLAUDE_BIN="$TEST_DIR/bin/claude" scripts/ralph/ralph.sh 2>&1)"
 
@@ -313,9 +311,9 @@ else
 fi
 
 echo -e "${YELLOW}--- ralph.sh backstop ---${NC}"
-EPIC4_JSON="$(scripts/ralph/fluxctl epic create --title "Ralph Epic 4" --json)"
+EPIC4_JSON="$(scripts/ralph/fluxctl epic create --title "Ralph Epic 4" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json)"
 EPIC4="$(echo "$EPIC4_JSON" | extract_id)"
-TASK4_1_JSON="$(scripts/ralph/fluxctl task create --epic "$EPIC4" --title "Stuck Task" --json)"
+TASK4_1_JSON="$(scripts/ralph/fluxctl task create --epic "$EPIC4" --title "Stuck Task" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json)"
 TASK4_1="$(echo "$TASK4_1_JSON" | extract_id)"
 write_config "none" "none" "0" "new" "3" "5" "2"
 STUB_MODE=retry CLAUDE_BIN="$TEST_DIR/bin/claude" scripts/ralph/ralph.sh >/dev/null
@@ -328,9 +326,9 @@ echo -e "${GREEN}✓${NC} blocks after attempts"
 PASS=$((PASS + 1))
 
 echo -e "${YELLOW}--- missing receipt forces retry ---${NC}"
-EPIC5_JSON="$(scripts/ralph/fluxctl epic create --title "Ralph Epic 5" --json)"
+EPIC5_JSON="$(scripts/ralph/fluxctl epic create --title "Ralph Epic 5" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json)"
 EPIC5="$(echo "$EPIC5_JSON" | extract_id)"
-TASK5_1_JSON="$(scripts/ralph/fluxctl task create --epic "$EPIC5" --title "Receipt Task" --json)"
+TASK5_1_JSON="$(scripts/ralph/fluxctl task create --epic "$EPIC5" --title "Receipt Task" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json)"
 TASK5_1="$(echo "$TASK5_1_JSON" | extract_id)"
 write_config "none" "rp" "0" "new" "3" "5" "1"
 set +e
@@ -361,9 +359,9 @@ fi
 echo -e "${YELLOW}--- non-zero exit code handling (#11) ---${NC}"
 # Test 1: task done + non-zero exit -> should NOT fail
 # This validates fix for issue #11 where transient errors caused false failures
-EPIC6_JSON="$(scripts/ralph/fluxctl epic create --title "Exit Code Epic 1" --json)"
+EPIC6_JSON="$(scripts/ralph/fluxctl epic create --title "Exit Code Epic 1" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json)"
 EPIC6="$(echo "$EPIC6_JSON" | extract_id)"
-TASK6_1_JSON="$(scripts/ralph/fluxctl task create --epic "$EPIC6" --title "Done but exit 1" --json)"
+TASK6_1_JSON="$(scripts/ralph/fluxctl task create --epic "$EPIC6" --title "Done but exit 1" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json)"
 TASK6_1="$(echo "$TASK6_1_JSON" | extract_id)"
 write_config "none" "none" "0" "new" "3" "5" "2"
 set +e
@@ -380,9 +378,9 @@ else
 fi
 
 # Test 2: task NOT done + non-zero exit -> should fail/block
-EPIC7_JSON="$(scripts/ralph/fluxctl epic create --title "Exit Code Epic 2" --json)"
+EPIC7_JSON="$(scripts/ralph/fluxctl epic create --title "Exit Code Epic 2" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json)"
 EPIC7="$(echo "$EPIC7_JSON" | extract_id)"
-TASK7_1_JSON="$(scripts/ralph/fluxctl task create --epic "$EPIC7" --title "Not done and exit 1" --json)"
+TASK7_1_JSON="$(scripts/ralph/fluxctl task create --epic "$EPIC7" --title "Not done and exit 1" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json)"
 TASK7_1="$(echo "$TASK7_1_JSON" | extract_id)"
 write_config "none" "none" "0" "new" "3" "5" "1"
 set +e

--- a/scripts/ralph_smoke_test.sh
+++ b/scripts/ralph_smoke_test.sh
@@ -31,6 +31,8 @@ RED='\033[0;31m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
+export FLUX_CREATE_APPROVAL="I_APPROVE_CREATING_EPICS_AND_TASKS"
+
 cleanup() {
   rm -rf "$TEST_DIR"
 }
@@ -56,6 +58,7 @@ scaffold() {
   cp -R "$PLUGIN_ROOT/skills/flux-ralph-init/templates/." scripts/ralph/
   cp "$PLUGIN_ROOT/scripts/fluxctl.py" scripts/ralph/fluxctl.py
   cp "$PLUGIN_ROOT/scripts/fluxctl" scripts/ralph/fluxctl
+  cp -R "$PLUGIN_ROOT/scripts/fluxctl_pkg" scripts/ralph/fluxctl_pkg
   chmod +x scripts/ralph/ralph.sh scripts/ralph/ralph_once.sh scripts/ralph/fluxctl
 }
 

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -45,7 +45,10 @@ git init -q
 
 cp "$PLUGIN_ROOT/scripts/fluxctl.py" scripts/fluxctl.py
 cp "$PLUGIN_ROOT/scripts/fluxctl" scripts/fluxctl
+cp -R "$PLUGIN_ROOT/scripts/fluxctl_pkg" scripts/fluxctl_pkg
 chmod +x scripts/fluxctl
+
+export FLUX_CREATE_APPROVAL="I_APPROVE_CREATING_EPICS_AND_TASKS"
 
 scripts/fluxctl init --json >/dev/null
 printf '{"commits":[],"tests":[],"prs":[]}' > "$TEST_DIR/evidence.json"

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -48,8 +48,6 @@ cp "$PLUGIN_ROOT/scripts/fluxctl" scripts/fluxctl
 cp -R "$PLUGIN_ROOT/scripts/fluxctl_pkg" scripts/fluxctl_pkg
 chmod +x scripts/fluxctl
 
-export FLUX_CREATE_APPROVAL="I_APPROVE_CREATING_EPICS_AND_TASKS"
-
 scripts/fluxctl init --json >/dev/null
 printf '{"commits":[],"tests":[],"prs":[]}' > "$TEST_DIR/evidence.json"
 printf "ok\n" > "$TEST_DIR/summary.md"
@@ -91,10 +89,10 @@ fi
 
 echo -e "${YELLOW}--- next: plan/work/none + priority ---${NC}"
 # Capture epic ID from create output (fn-N-xxx format)
-EPIC1_JSON="$(scripts/fluxctl epic create --title "Epic One" --json)"
+EPIC1_JSON="$(scripts/fluxctl epic create --title "Epic One" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json)"
 EPIC1="$(echo "$EPIC1_JSON" | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
-scripts/fluxctl task create --epic "$EPIC1" --title "Low pri" --priority 5 --json >/dev/null
-scripts/fluxctl task create --epic "$EPIC1" --title "High pri" --priority 1 --json >/dev/null
+scripts/fluxctl task create --epic "$EPIC1" --title "Low pri" --priority 5 --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
+scripts/fluxctl task create --epic "$EPIC1" --title "High pri" --priority 1 --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
 
 plan_json="$(scripts/fluxctl next --require-plan-review --json)"
 "$PYTHON_BIN" - "$plan_json" "$EPIC1" <<'PY'
@@ -241,10 +239,10 @@ PASS=$((PASS + 1))
 
 echo -e "${YELLOW}--- epic set-title ---${NC}"
 # Create epic with tasks for rename test
-RENAME_EPIC_JSON="$(scripts/fluxctl epic create --title "Old Title" --json)"
+RENAME_EPIC_JSON="$(scripts/fluxctl epic create --title "Old Title" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json)"
 RENAME_EPIC="$(echo "$RENAME_EPIC_JSON" | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
-scripts/fluxctl task create --epic "$RENAME_EPIC" --title "First task" --json >/dev/null
-scripts/fluxctl task create --epic "$RENAME_EPIC" --title "Second task" --json >/dev/null
+scripts/fluxctl task create --epic "$RENAME_EPIC" --title "First task" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
+scripts/fluxctl task create --epic "$RENAME_EPIC" --title "Second task" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
 # Add task dependency within epic
 scripts/fluxctl dep add "${RENAME_EPIC}.2" "${RENAME_EPIC}.1" --json >/dev/null
 
@@ -322,7 +320,7 @@ echo -e "${GREEN}✓${NC} set-title show works with new ID"
 PASS=$((PASS + 1))
 
 # Test 7: depends_on_epics update in other epics
-DEP_EPIC_JSON="$(scripts/fluxctl epic create --title "Depends on renamed" --json)"
+DEP_EPIC_JSON="$(scripts/fluxctl epic create --title "Depends on renamed" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json)"
 DEP_EPIC="$(echo "$DEP_EPIC_JSON" | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
 scripts/fluxctl epic add-dep "$DEP_EPIC" "$NEW_EPIC" --json >/dev/null
 # Rename the dependency
@@ -342,10 +340,10 @@ echo -e "${GREEN}✓${NC} set-title updates depends_on_epics in other epics"
 PASS=$((PASS + 1))
 
 echo -e "${YELLOW}--- block + validate + epic close ---${NC}"
-EPIC2_JSON="$(scripts/fluxctl epic create --title "Epic Two" --json)"
+EPIC2_JSON="$(scripts/fluxctl epic create --title "Epic Two" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json)"
 EPIC2="$(echo "$EPIC2_JSON" | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
-scripts/fluxctl task create --epic "$EPIC2" --title "Block me" --json >/dev/null
-scripts/fluxctl task create --epic "$EPIC2" --title "Other" --json >/dev/null
+scripts/fluxctl task create --epic "$EPIC2" --title "Block me" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
+scripts/fluxctl task create --epic "$EPIC2" --title "Other" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
 printf "Blocked by test\n" > "$TEST_DIR/reason.md"
 scripts/fluxctl block "${EPIC2}.1" --reason-file "$TEST_DIR/reason.md" --json >/dev/null
 scripts/fluxctl validate --epic "$EPIC2" --json >/dev/null
@@ -631,9 +629,9 @@ echo -e "${YELLOW}--- codex e2e (requires codex CLI) ---${NC}"
 codex_available="$(scripts/fluxctl codex check --json 2>/dev/null | "$PYTHON_BIN" -c "import sys,json; print(json.load(sys.stdin).get('available', False))" 2>/dev/null || echo "False")"
 if [[ "$codex_available" == "True" ]]; then
   # Create a simple epic + task for testing
-  EPIC3_JSON="$(scripts/fluxctl epic create --title "Codex test epic" --json)"
+  EPIC3_JSON="$(scripts/fluxctl epic create --title "Codex test epic" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json)"
   EPIC3="$(echo "$EPIC3_JSON" | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
-  scripts/fluxctl task create --epic "$EPIC3" --title "Test task" --json >/dev/null
+  scripts/fluxctl task create --epic "$EPIC3" --title "Test task" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
 
   # Write a simple spec
   cat > ".flux/specs/${EPIC3}.md" << 'EOF'
@@ -733,10 +731,10 @@ fi
 echo -e "${YELLOW}--- depends_on_epics gate ---${NC}"
 cd "$TEST_DIR/repo"  # Back to test repo
 # Create epics and capture their IDs
-DEP_BASE_JSON="$(scripts/fluxctl epic create --title "Dep base" --json)"
+DEP_BASE_JSON="$(scripts/fluxctl epic create --title "Dep base" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json)"
 DEP_BASE_ID="$(echo "$DEP_BASE_JSON" | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
-scripts/fluxctl task create --epic "$DEP_BASE_ID" --title "Base task" --json >/dev/null
-DEP_CHILD_JSON="$(scripts/fluxctl epic create --title "Dep child" --json)"
+scripts/fluxctl task create --epic "$DEP_BASE_ID" --title "Base task" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
+DEP_CHILD_JSON="$(scripts/fluxctl epic create --title "Dep child" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json)"
 DEP_CHILD_ID="$(echo "$DEP_CHILD_JSON" | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
 "$PYTHON_BIN" - "$DEP_CHILD_ID" "$DEP_BASE_ID" <<'PY'
 import json, sys
@@ -762,7 +760,7 @@ PASS=$((PASS + 1))
 
 echo -e "${YELLOW}--- stdin support ---${NC}"
 cd "$TEST_DIR/repo"
-STDIN_EPIC_JSON="$(scripts/fluxctl epic create --title "Stdin test" --json)"
+STDIN_EPIC_JSON="$(scripts/fluxctl epic create --title "Stdin test" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json)"
 STDIN_EPIC="$(echo "$STDIN_EPIC_JSON" | "$PYTHON_BIN" -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
 # Test epic set-plan with stdin
 scripts/fluxctl epic set-plan "$STDIN_EPIC" --file - --json <<'EOF'
@@ -781,7 +779,7 @@ echo -e "${GREEN}✓${NC} stdin epic set-plan"
 PASS=$((PASS + 1))
 
 echo -e "${YELLOW}--- task set-spec combined ---${NC}"
-scripts/fluxctl task create --epic "$STDIN_EPIC" --title "Set-spec test" --json >/dev/null
+scripts/fluxctl task create --epic "$STDIN_EPIC" --title "Set-spec test" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
 SETSPEC_TASK="${STDIN_EPIC}.1"
 # Write temp files for combined set-spec
 echo 'This is the description.' > "$TEST_DIR/desc.md"
@@ -796,7 +794,7 @@ echo -e "${GREEN}✓${NC} task set-spec combined"
 PASS=$((PASS + 1))
 
 echo -e "${YELLOW}--- task set-spec --file (full replacement) ---${NC}"
-scripts/fluxctl task create --epic "$STDIN_EPIC" --title "Full replacement test" --json >/dev/null
+scripts/fluxctl task create --epic "$STDIN_EPIC" --title "Full replacement test" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
 FULLREPLACE_TASK="${STDIN_EPIC}.2"
 # Write complete spec file
 cat > "$TEST_DIR/full_spec.md" << 'FULLSPEC'
@@ -820,7 +818,7 @@ echo -e "${GREEN}✓${NC} task set-spec --file"
 PASS=$((PASS + 1))
 
 echo -e "${YELLOW}--- task set-spec --file stdin ---${NC}"
-scripts/fluxctl task create --epic "$STDIN_EPIC" --title "Stdin replacement test" --json >/dev/null
+scripts/fluxctl task create --epic "$STDIN_EPIC" --title "Stdin replacement test" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json >/dev/null
 STDIN_REPLACE_TASK="${STDIN_EPIC}.3"
 # Full replacement via stdin
 scripts/fluxctl task set-spec "$STDIN_REPLACE_TASK" --file - --json <<'EOF'

--- a/skills/flux-plan/SKILL.md
+++ b/skills/flux-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flux-plan
-description: Create structured build plans from feature requests or Flow IDs. Use when planning features or designing implementation. Triggers on /flux:plan with text descriptions or Flow IDs (fn-1-add-oauth, fn-1-add-oauth.2, or legacy fn-1, fn-1.2, fn-1-xxx, fn-1-xxx.2).
+description: Create structured build plans from feature, bugfix, upgrade, or refactor requests, or from Flow IDs. Use when planning implementation after the workflow envelope is explicit. Triggers on /flux:plan with text descriptions or Flow IDs (fn-1-add-oauth, fn-1-add-oauth.2, or legacy fn-1, fn-1.2, fn-1-xxx, fn-1-xxx.2).
 user-invocable: false
 ---
 
@@ -101,7 +101,7 @@ Every non-trivial plan must include a future-pressure pass: forecast likely foll
 Full request: $ARGUMENTS
 
 Accepts:
-- Feature/bug description in natural language
+- Feature/bug/upgrade/refactor description in natural language
 - Flow epic ID `fn-N-slug` (e.g., `fn-1-add-oauth`) or legacy `fn-N`/`fn-N-xxx` to refine existing epic
 - Flow task ID `fn-N-slug.M` (e.g., `fn-1-add-oauth.2`) or legacy `fn-N.M`/`fn-N-xxx.M` to refine specific task
 - Chained instructions like "then review with /flux:plan-review"
@@ -112,7 +112,23 @@ Examples:
 - `/flux:plan fn-1` (legacy formats fn-1, fn-1-xxx still supported)
 - `/flux:plan fn-1-add-oauth then review via /flux:plan-review`
 
-If empty, ask: "What should I plan? Give me the feature or bug in 1-5 sentences."
+If empty, ask: "What should I plan? Give me the feature, bug, upgrade, or refactor in 1-5 sentences."
+
+## Workflow Envelope Gate
+
+Before detailed planning, make the workflow envelope explicit.
+
+Always confirm:
+- **Objective kind**: `feature`, `bug`, `upgrade`, or `refactor`
+- **Technical level**: `non_technical`, `semi_technical`, or `technical`
+- **Planning path**: shallow planning directly in `/flux:plan`, or escalate to deep Double Diamond scoping first via `/flux:scope --deep`
+
+Rules:
+- If the user is **non-technical / stakeholder**, route to `flux-propose` instead of continuing in `flux-plan`.
+- If the user wants **deep Double Diamond**, switch to `/flux:scope --deep` and stop the direct plan flow there.
+- If the user wants **shallow planning**, continue in `/flux:plan`.
+- If the request is improving an existing feature rather than creating a net-new one, classify it as **`upgrade`**.
+- Do not silently assume shallow planning just because the user did not say `--deep`.
 
 ## FIRST: Parse Options or Ask Questions
 
@@ -138,7 +154,7 @@ Parse the arguments for these patterns. If found, use them and skip questions:
 
 ### If options NOT found in arguments
 
-**Plan depth** (parse from args or ask):
+**Plan depth** (this is the plan artifact depth after the workflow envelope has already established whether shallow planning is sufficient or whether deep scope should run first):
 - `--depth=short` or "quick" or "minimal" → SHORT
 - `--depth=standard` or "normal" → STANDARD
 - `--depth=deep` or "comprehensive" or "detailed" → DEEP

--- a/skills/flux-plan/SKILL.md
+++ b/skills/flux-plan/SKILL.md
@@ -67,6 +67,15 @@ Continue regardless (non-blocking).
 **Goal**: produce an epic with tasks that match existing conventions and reuse points.
 **Task size**: every task must fit one `/flux:work` iteration (~100k tokens max). If it won't, split it.
 
+## Mandatory Approval Gate
+
+Before any `epic create` or `task create` call, get explicit developer approval.
+
+- Prefer the question tool / AskUserQuestion when available.
+- If you cannot use a question tool, require the developer to type exactly: `I_APPROVE_CREATING_EPICS_AND_TASKS`
+- Until approval is explicit, do not create any epic or task. You may research, propose the structure, and wait.
+- After approval, pass `--approve "I_APPROVE_CREATING_EPICS_AND_TASKS"` on every `fluxctl epic create` and `fluxctl task create` call in this run.
+
 Every non-trivial plan must include a future-pressure pass: forecast likely follow-on features, failure modes, reuse pressure, and reversal cost before tasks are finalized. Do not turn this into a giant ceremony for trivial changes; go deep only on one-way doors and shared surfaces.
 
 ## The Golden Rule: No Implementation Code

--- a/skills/flux-plan/steps.md
+++ b/skills/flux-plan/steps.md
@@ -211,20 +211,25 @@ Default to standard unless complexity demands more or less.
 
 **Route B - Input was text (new idea)**:
 
-1. Create epic:
+1. Present the proposed epic title, rough task breakdown, and any epic split to the developer, then get explicit approval before writing anything:
+   - Prefer the question tool / AskUserQuestion
+   - Fallback: require the developer to type exactly `I_APPROVE_CREATING_EPICS_AND_TASKS`
+   - If approval is missing, stop here. Do not create epics or tasks.
+
+2. Create epic:
    ```bash
-   $FLUXCTL epic create --title "<Short title>" --json
+   $FLUXCTL epic create --title "<Short title>" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json
    ```
    This returns the epic ID (e.g., fn-1-add-oauth).
 
-2. Set epic branch_name (deterministic):
+3. Set epic branch_name (deterministic):
    - Default: use epic ID (e.g., fn-1-add-oauth)
    ```bash
    $FLUXCTL epic set-branch <epic-id> --branch "<epic-id>" --json
    ```
    - If user specified a branch, use that instead.
 
-3. Write epic spec (use stdin heredoc):
+4. Write epic spec (use stdin heredoc):
    ```bash
    # Include: Overview, Scope, Approach, Future Pressure, Quick commands (REQUIRED), Acceptance, References
    # Add mermaid diagram if data model or architecture changes
@@ -249,7 +254,7 @@ Default to standard unless complexity demands more or less.
    EOF
    ```
 
-4. Set epic dependencies (from epic-scout findings):
+5. Set epic dependencies (from epic-scout findings):
 
    If epic-scout found dependencies, set them automatically:
    ```bash
@@ -264,18 +269,18 @@ Default to standard unless complexity demands more or less.
    - fn-N-slug → fn-5-user-model (DB): Extends User model
    ```
 
-5. Create child tasks:
+6. Create child tasks:
    ```bash
    # Task with no dependencies:
-   $FLUXCTL task create --epic <epic-id> --title "<Task title>" --json
+   $FLUXCTL task create --epic <epic-id> --title "<Task title>" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json
 
    # Task with dependencies (use --deps for inline dependency declaration):
-   $FLUXCTL task create --epic <epic-id> --title "<Task title>" --deps <dep1>,<dep2> --json
+   $FLUXCTL task create --epic <epic-id> --title "<Task title>" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --deps <dep1>,<dep2> --json
    ```
 
    **TIP**: Use `--deps` to declare dependencies inline when creating tasks. Tasks must exist before being referenced, so create in dependency order.
 
-6. Write task specs (use combined set-spec):
+7. Write task specs (use combined set-spec):
    ```bash
    # For each task - single call sets both sections
    # Write description and acceptance to temp files, then:
@@ -309,7 +314,7 @@ Default to standard unless complexity demands more or less.
    - [ ] Criterion 2
    ```
 
-7. Add task dependencies (if not already set via `--deps`):
+8. Add task dependencies (if not already set via `--deps`):
 
    **Preferred**: Use `--deps` flag during task creation (step 5). This saves tool calls.
 
@@ -322,7 +327,7 @@ Default to standard unless complexity demands more or less.
 
    Use `dep add` when you need to add dependencies to existing tasks or fix missed dependencies.
 
-8. Output current state:
+9. Output current state:
    ```bash
    $FLUXCTL show <epic-id> --json
    $FLUXCTL cat <epic-id>

--- a/skills/flux-propose/SKILL.md
+++ b/skills/flux-propose/SKILL.md
@@ -5,7 +5,8 @@ description: >-
   a conversational planning session — probes for business context, pushes back like an
   engineer, estimates complexity and cost, then documents the proposal and creates a PR
   for engineering handoff. Triggers: /flux:propose, or detected implicitly when a
-  non-technical user describes a feature without implementation detail during /flux:scope.
+  non-technical user describes a feature, bugfix request, or upgrade without implementation
+  detail during /flux:scope or /flux:plan.
 user-invocable: false
 ---
 
@@ -110,14 +111,14 @@ If arguments provided:
 
 ## Implicit Detection (from /flux:scope)
 
-This skill can be triggered implicitly when `/flux:scope` detects a non-technical user. Detection signals:
+This skill can be triggered implicitly when `/flux:scope` or `/flux:plan` detects a non-technical user. Detection signals:
 
 - Language focuses on **outcomes** not implementation ("I want users to be able to..." vs "Add an API endpoint for...")
 - No technical terms (no mention of APIs, databases, components, endpoints, schemas)
 - Describes **what** without **how**
 - Talks about business goals, customer needs, or user experience without referencing architecture
 
-When detected, `/flux:scope` asks:
+When detected, Flux asks:
 
 > "It sounds like you're describing what you'd like built rather than how to build it. Are you an engineer planning to implement this, or are you proposing a feature for the engineering team?"
 

--- a/skills/flux-scope/SKILL.md
+++ b/skills/flux-scope/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flux-scope
-description: Use when scoping a new feature, refactor, or ambiguous bugfix into a concrete Flow objective. Guides Start, Discover, Define, Stress Test, Future Pressure, Develop, Deliver, and Handoff; supports shallow mode by default and `--deep` for the full staged flow. Triggers on literal `/flux:scope`, including prompts like `/flux:scope Add OAuth login` or `/flux:scope fn-1 --deep`.
+description: Use when scoping a new feature, bugfix, upgrade to an existing feature, or refactor into a concrete Flow objective. Guides Start, Discover, Define, Stress Test, Future Pressure, Develop, Deliver, and Handoff; requires an explicit shallow-vs-deep choice before scoping continues. Triggers on literal `/flux:scope`, including prompts like `/flux:scope Add OAuth login` or `/flux:scope fn-1 --deep`.
 user-invocable: false
 ---
 
@@ -14,7 +14,7 @@ START -> DISCOVER -> DEFINE -> STRESS TEST -> FUTURE PRESSURE -> DEVELOP -> DELI
 ```
 
 **Modes**:
-- **Shallow (default)**: ~10 min total. Compressed scoping for smaller or clearer work.
+- **Shallow**: ~10 min total. Compressed scoping for smaller or clearer work.
 - **Deep (`--deep`)**: ~45 min total. Full staged workflow with stronger gates, more edge cases, and richer handoff.
 - **Explore (`--explore [N]`)**: Generate N competing approaches, scaffold each in parallel, compare visually, pick winner.
 
@@ -70,7 +70,7 @@ Continue regardless (non-blocking).
 **State Machine**: See [docs/state-machine.md](../../docs/state-machine.md) for the formal workflow state diagram, valid transitions, and routing rules. This skill is the primary entry point from `fresh_session_no_objective` state.
 
 **Role**: product-minded technical interviewer and planner
-**Goal**: understand the problem deeply, keep the user aligned to the current workflow, then create actionable implementation context
+**Goal**: understand the problem deeply, keep the user aligned to the current workflow, make the workflow envelope explicit up front, then create actionable implementation context
 
 ## Input
 
@@ -98,7 +98,7 @@ Examples:
 - `/flux:scope LIN-42` — Scope Linear issue LIN-42 directly
 - `/flux:scope PROJ-123 --deep` — Deep scope Linear issue PROJ-123
 
-If empty, ask: "What should I scope? Describe the feature or bug in 1-5 sentences."
+If empty, ask: "What should I scope? Describe the feature, bug, upgrade, or refactor in 1-5 sentences."
 
 ## Load Business And Architecture Context
 
@@ -120,32 +120,42 @@ If business context exists:
 
 If no business context exists: continue normally.
 
-## Detect Stakeholder vs Engineer
+## Establish Workflow Envelope
 
-Before detecting mode, check if the user is a non-technical stakeholder rather than an engineer.
+Before any deeper routing or scoping questions, explicitly establish the workflow envelope for this objective.
 
-**Skip detection entirely if ANY of these are present** (strong engineer signals):
-- Mentions specific files, paths, or line numbers
-- References APIs, endpoints, databases, schemas, components, services, or architecture
-- Uses technical verbs: "refactor", "migrate", "deploy", "integrate", "implement"
-- Includes code snippets, error messages, or stack traces
+**This is mandatory on every new scope. Do not rely on silent heuristics alone.**
 
-**Detection signals** (check the input text if no engineer signals found):
-- Language focuses on **outcomes** not implementation ("I want users to be able to..." vs "Add an API endpoint for...")
-- Describes **what** without **how**
-- Talks about business goals, customer needs, revenue, or user experience
-- Uses non-technical framing: "customers want...", "our team needs...", "it would be great if..."
+Always make these four fields explicit:
+- **Objective kind**: `feature`, `bug`, `upgrade`, or `refactor`
+- **Technical level**: `non_technical`, `semi_technical`, or `technical`
+- **Scope depth**: `shallow` or `deep`
+- **Implementation target**: `self_with_ai` or `engineer_handoff`
 
-If 3+ signals are present and zero engineer signals, ask:
+Use request heuristics only to pre-fill likely defaults. Then confirm them with the user before continuing.
 
-> "It sounds like you're describing what you'd like built rather than how to build it. Are you an engineer planning to implement this, or are you proposing a feature for the engineering team?"
+**Heuristics for likely defaults**:
+- **Engineer signals**: file paths, line numbers, APIs, endpoints, schemas, components, services, architecture terms, code snippets, stack traces, or verbs like "refactor", "migrate", "deploy", "integrate", "implement"
+- **Stakeholder signals**: outcome-focused language, business goals, customer pain, revenue/user-experience framing, and descriptions of what without how
+- **Bug signals**: errors, regressions, "broken", "not working", "fails", "wrong output"
+- **Upgrade signals**: extend, expand, improve, upgrade, enhance, add capability to an existing feature without replacing it wholesale
+- **Refactor signals**: restructure, simplify, extract, split, clean up, reduce coupling, improve maintainability without changing product behavior
 
-- If **stakeholder** → hand off to `flux-propose` skill with their input preserved. Stop here.
-- If **engineer** → continue with `/flux:scope` normally.
+Ask explicitly unless the user already specified every field in the command. A good envelope question is:
+
+> "Before I scope this, I want to lock the workflow envelope: is this a feature, bug, upgrade, or refactor? Are you approaching this as a technical implementer or a non-technical stakeholder? Do you want shallow planning or the full deep Double Diamond? And is the output for you to build with AI, or for engineer handoff?"
+
+**Rules**:
+- If the user explicitly says they are **non-technical / stakeholder**, route to `flux-propose` with their input preserved. Stop here.
+- If heuristics strongly suggest stakeholder, still ask the explicit technical-level question before routing.
+- If the user chooses **deep**, set `scope_mode=deep`.
+- If the user chooses **shallow**, set `scope_mode=shallow`.
+- If the user already passed `--deep`, reflect that back as the current selection when asking the envelope question instead of silently assuming it.
+- If the request is best described as improving or extending an existing shipped capability, classify it as **`upgrade`** instead of collapsing it into `feature`.
 
 ## Detect React Visual Jank
 
-After stakeholder detection, check whether the request is really a React visual-jank complaint that should route to Dejank instead of the normal scoping flow.
+After the workflow envelope is confirmed, check whether the request is really a React visual-jank complaint that should route to Dejank instead of the normal scoping flow.
 
 **Preconditions:**
 - Repo looks React-based (`react`, `next`, `@remix-run/react`, `react-router`, etc.)
@@ -163,9 +173,9 @@ If those signals are strong and Dejank is available, ask:
 - If **yes** → hand off to `dejank` with the user input preserved. Stop here.
 - If **no** → continue with `/flux:scope` normally.
 
-## Detect Bug vs Feature
+## Refine Bug Routing
 
-After stakeholder detection, check if this is a bug report that should route to RCA.
+After the workflow envelope is confirmed, check if this is a bug report that should route to RCA.
 
 **Bug signals** (check the input text):
 - Contains error messages, stack traces, or exception names
@@ -180,13 +190,13 @@ If bug signals are strong, ask:
 - If **yes** → hand off to `flux-rca` skill with their input preserved. Stop here.
 - If **no** → continue with `/flux:scope` normally (user may want to scope a larger fix around the bug).
 
-If unclear (could be a bug or a feature gap), ask:
+If unclear (could be a bug or an upgrade/feature gap), ask:
 
-> "Am I right in thinking this is a bug? Or is this more of a missing feature / improvement?"
+> "Am I right in thinking this is a bug? Or is this more of an upgrade / missing feature?"
 
-## Detect Mode
+## Confirm Scope Mode
 
-Parse arguments for `--deep` flag. Default is shallow mode.
+Parse arguments for `--deep` / `--quick` as a provisional default only. The user must still have the scope depth made explicit in the workflow envelope before Discover begins.
 
 ```
 SCOPE_MODE = "--deep" in arguments ? "deep" : "shallow"

--- a/skills/flux-scope/phases.md
+++ b/skills/flux-scope/phases.md
@@ -19,7 +19,7 @@ START -> DISCOVER -> DEFINE -> STRESS TEST -> FUTURE PRESSURE -> DEVELOP -> DELI
 ```
 
 At all times, Flux should persist:
-- objective kind: feature, bug, or refactor
+- objective kind: feature, bug, upgrade, or refactor
 - scope mode: shallow or deep
 - technical level
 - implementation target
@@ -34,15 +34,24 @@ Use `fluxctl scope-status` to render a progress card after each major transition
 **Purpose**: Establish the workflow envelope before asking deeper questions.
 
 **Always capture**:
-- feature, bug, or refactor
+- feature, bug, upgrade, or refactor
 - shallow or deep
 - technical level
 - self with AI or engineer handoff
 
 **Why this matters**:
+- Upgrade work is different from net-new feature work and should not be collapsed into a generic feature bucket.
 - Shallow and deep mode should feel different.
 - Non-technical users should get stronger defaults.
 - Engineer handoff should produce richer deliverables than self-build mode.
+- The user should know which gate they are in before Flux advances to the next one.
+
+**Mandatory gates in START**:
+1. Classify the work: feature, bug, upgrade, or refactor.
+2. Confirm whether the user is technical or non-technical.
+3. Confirm whether shallow planning is sufficient or whether they want the full deep Double Diamond.
+4. Confirm whether the output is for self-build with AI or engineer handoff.
+5. Show the current gate and completed gates in plain language before entering DISCOVER.
 
 ---
 
@@ -234,7 +243,7 @@ See [stress-test.md](stress-test.md) for full execution details.
 After DEFINE, present the proposed epic, get explicit approval, then start persisting structured workflow state:
 ```bash
 $FLUXCTL epic create --title "<from problem statement>" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json
-$FLUXCTL epic set-context <id> --kind feature --scope-mode shallow --activate
+$FLUXCTL epic set-context <id> --kind <confirmed-kind> --scope-mode <confirmed-mode> --activate
 $FLUXCTL epic set-workflow <id> --phase define --step problem-statement --status in_progress
 $FLUXCTL epic set-plan <id> --file - <<'EOF'
 # Problem Statement
@@ -246,6 +255,7 @@ EOF
 ```
 
 This anchors the remaining workflow to the defined problem.
+Do not create the epic until the START envelope has been confirmed and the developer has explicitly approved persistence.
 
 ### Deliver → Work Handoff
 

--- a/skills/flux-scope/phases.md
+++ b/skills/flux-scope/phases.md
@@ -231,7 +231,7 @@ See [stress-test.md](stress-test.md) for full execution details.
 
 ### Define → Deliver Handoff
 
-After DEFINE, create the epic immediately and start persisting structured workflow state:
+After DEFINE, present the proposed epic, get explicit approval, then start persisting structured workflow state:
 ```bash
 $FLUXCTL epic create --title "<from problem statement>" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json
 $FLUXCTL epic set-context <id> --kind feature --scope-mode shallow --activate

--- a/skills/flux-scope/phases.md
+++ b/skills/flux-scope/phases.md
@@ -233,7 +233,7 @@ See [stress-test.md](stress-test.md) for full execution details.
 
 After DEFINE, create the epic immediately and start persisting structured workflow state:
 ```bash
-$FLUXCTL epic create --title "<from problem statement>" --json
+$FLUXCTL epic create --title "<from problem statement>" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json
 $FLUXCTL epic set-context <id> --kind feature --scope-mode shallow --activate
 $FLUXCTL epic set-workflow <id> --phase define --step problem-statement --status in_progress
 $FLUXCTL epic set-plan <id> --file - <<'EOF'

--- a/skills/flux-scope/solution.md
+++ b/skills/flux-scope/solution.md
@@ -121,12 +121,21 @@ If the user selects **"Unassigned"**, omit the assignee field when creating issu
 
 ---
 
+## Step 6.75: Approval Gate Before Any Writes
+
+Before creating any epic or task, show the developer the proposed epic structure and rough task breakdown, then get explicit approval.
+
+- Prefer `AskUserQuestion` / the question tool when available.
+- Fallback: require the developer to type exactly `I_APPROVE_CREATING_EPICS_AND_TASKS`.
+- If approval is missing, stop after presenting the proposed structure. Do not create epics or tasks.
+- After approval, pass `--approve "I_APPROVE_CREATING_EPICS_AND_TASKS"` on every `fluxctl epic create` and `fluxctl task create` call in this run.
+
 ## Step 7: Create Epic
 
 Create the epic with the problem statement:
 
 ```bash
-$FLUXCTL epic create --title "<Short title from problem statement>" --json
+$FLUXCTL epic create --title "<Short title from problem statement>" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json
 ```
 
 Write the problem space findings to the epic spec. **The epic spec is the high-level business context** — an agent or human reading this should understand *why* this work exists, *who* it impacts, and *what success looks like*. Implementation details belong in task specs, not here.
@@ -328,14 +337,14 @@ Tasks at the same dependency level CAN run in parallel. Call this out explicitly
 
 ```bash
 # Create tasks in dependency order — first task has no deps
-$FLUXCTL task create --epic <epic-id> --title "<Foundation task>" --json
+$FLUXCTL task create --epic <epic-id> --title "<Foundation task>" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json
 # → returns fn-1-slug.1
 
-$FLUXCTL task create --epic <epic-id> --title "<Task that needs foundation>" --deps fn-1-slug.1 --json
+$FLUXCTL task create --epic <epic-id> --title "<Task that needs foundation>" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --deps fn-1-slug.1 --json
 # → returns fn-1-slug.2
 
 # Multiple deps for tasks that need several predecessors
-$FLUXCTL task create --epic <epic-id> --title "<Integration task>" --deps fn-1-slug.2,fn-1-slug.3 --json
+$FLUXCTL task create --epic <epic-id> --title "<Integration task>" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --deps fn-1-slug.2,fn-1-slug.3 --json
 ```
 
 ### Task Spec Content
@@ -434,7 +443,7 @@ Detect if the epic touches frontend/web UI by checking:
 **If YES** — create a Browser QA Checklist task:
 
 ```bash
-$FLUXCTL task create --epic <epic-id> --title "Browser QA Checklist" --json
+$FLUXCTL task create --epic <epic-id> --title "Browser QA Checklist" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json
 ```
 
 Set its spec with testable acceptance criteria derived from the epic's acceptance criteria and task specs. Each criterion must be concrete and browser-testable:

--- a/skills/flux-setup/templates/claude-md-snippet.md
+++ b/skills/flux-setup/templates/claude-md-snippet.md
@@ -105,15 +105,16 @@ This project uses Flux for structured AI development. Use `.flux/bin/fluxctl` in
 - If the user clearly starts a new objective while another is active, ask whether to switch objectives, then use `.flux/bin/fluxctl objective switch <epic-id>` when needed.
 </important>
 
-<important if="you are starting a new scope or scoping a feature, bug, or refactor">
+<important if="you are starting a new scope or scoping a feature, bug, upgrade, or refactor">
 **Scoping rules:**
 - `/flux:scope` is the full scoping workflow: Start -> Discover -> Define -> Develop -> Deliver -> Handoff.
 - Prime is the first workflow step in a repository. If the repo is not primed yet, do that automatically before starting scope.
 - At the start of a new scope, ask:
-  - is this a feature, bug, or refactor?
+  - is this a feature, bug, upgrade, or refactor?
+  - is the user technical or non-technical?
   - should we go shallow or deep?
-  - how technical is the user?
   - are they implementing it with AI or handing it to an engineer?
+ - If the user is non-technical, route to `/flux:propose`.
 - During scoping, show progress with `.flux/bin/fluxctl scope-status`.
 - Persist phase changes and artifacts through `fluxctl` instead of relying on chat memory alone.
 - Treat `.flux/brain/codebase/architecture.md` as the canonical whole-product architecture note.

--- a/skills/flux-setup/templates/usage.md
+++ b/skills/flux-setup/templates/usage.md
@@ -53,9 +53,9 @@ Task tracking for AI agents. All state lives in `.flux/`.
 .flux/bin/fluxctl agentmap --write             # Write .flux/context/agentmap.yaml
 
 # Create
-.flux/bin/fluxctl epic create --title "..."
-.flux/bin/fluxctl task create --epic fn-1-add-oauth --title "..."
-.flux/bin/fluxctl task create --epic fn-1-add-oauth --title "..." --deps fn-1-add-oauth.1,fn-1-add-oauth.2
+.flux/bin/fluxctl epic create --title "..." --approve "I_APPROVE_CREATING_EPICS_AND_TASKS"
+.flux/bin/fluxctl task create --epic fn-1-add-oauth --title "..." --approve "I_APPROVE_CREATING_EPICS_AND_TASKS"
+.flux/bin/fluxctl task create --epic fn-1-add-oauth --title "..." --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --deps fn-1-add-oauth.1,fn-1-add-oauth.2
 
 # Dependencies
 .flux/bin/fluxctl task set-deps fn-1-add-oauth.3 --deps fn-1-add-oauth.1,fn-1-add-oauth.2

--- a/skills/flux-work/phases.md
+++ b/skills/flux-work/phases.md
@@ -51,16 +51,22 @@ Detect input type in this order (first match wins):
 1. Check file exists: `test -f "<path>"` — if not, treat as idea text
 2. Initialize: `$FLUXCTL init --json`
 3. Read file and extract title from first `# Heading` or use filename
-4. Create epic: `$FLUXCTL epic create --title "<extracted-title>" --json`
-5. Set spec from file: `$FLUXCTL epic set-plan <epic-id> --file <path> --json`
-6. Create single task: `$FLUXCTL task create --epic <epic-id> --title "Implement <title>" --json`
-7. Continue with epic-id
+4. Before creating anything, get explicit developer approval:
+   - Prefer the question tool / AskUserQuestion
+   - Fallback: require the developer to type exactly `I_APPROVE_CREATING_EPICS_AND_TASKS`
+5. Create epic: `$FLUXCTL epic create --title "<extracted-title>" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json`
+6. Set spec from file: `$FLUXCTL epic set-plan <epic-id> --file <path> --json`
+7. Create single task: `$FLUXCTL task create --epic <epic-id> --title "Implement <title>" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json`
+8. Continue with epic-id
 
 **Spec-less start (idea text)**:
 1. Initialize: `$FLUXCTL init --json`
-2. Create epic: `$FLUXCTL epic create --title "<idea>" --json`
-3. Create single task: `$FLUXCTL task create --epic <epic-id> --title "Implement <idea>" --json`
-4. Continue with epic-id
+2. Before creating anything, get explicit developer approval:
+   - Prefer the question tool / AskUserQuestion
+   - Fallback: require the developer to type exactly `I_APPROVE_CREATING_EPICS_AND_TASKS`
+3. Create epic: `$FLUXCTL epic create --title "<idea>" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json`
+4. Create single task: `$FLUXCTL task create --epic <epic-id> --title "Implement <idea>" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json`
+5. Continue with epic-id
 
 ### Linear Status Sync
 

--- a/skills/flux/SKILL.md
+++ b/skills/flux/SKILL.md
@@ -19,6 +19,12 @@ FLUXCTL="${PLUGIN_ROOT}/scripts/fluxctl"
 
 Then run commands with `$FLUXCTL <command>`.
 
+**Approval gate for creation:**
+- Before any `epic create` or `task create`, get explicit developer approval first.
+- Prefer the question tool / AskUserQuestion when available.
+- Fallback: require the developer to type exactly `I_APPROVE_CREATING_EPICS_AND_TASKS`.
+- Pass `--approve "I_APPROVE_CREATING_EPICS_AND_TASKS"` on the create command after approval.
+
 **Discover all commands/options:**
 ```bash
 $FLUXCTL --help
@@ -63,7 +69,7 @@ $FLUXCTL cat fn-1-add-oauth.2            # Task spec
 $FLUXCTL ready --epic fn-1-add-oauth --json
 
 # Create task under existing epic
-$FLUXCTL task create --epic fn-1-add-oauth --title "Fix bug X" --json
+$FLUXCTL task create --epic fn-1-add-oauth --title "Fix bug X" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json
 
 # Set task description and acceptance (combined, fewer writes)
 $FLUXCTL task set-spec fn-1-add-oauth.2 --description /tmp/desc.md --acceptance /tmp/accept.md --json
@@ -101,7 +107,7 @@ $FLUXCTL validate --all --json
 
 2. Create task:
    ```bash
-   $FLUXCTL task create --epic fn-N --title "Short title" --json
+   $FLUXCTL task create --epic fn-N --title "Short title" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json
    ```
 
 3. Add description + acceptance (combined):
@@ -161,7 +167,7 @@ $FLUXCTL cat fn-1-add-oauth.2           # Full spec
 ### Create new epic (rare - usually via /flux:plan)
 
 ```bash
-$FLUXCTL epic create --title "Epic title" --json
+$FLUXCTL epic create --title "Epic title" --approve "I_APPROVE_CREATING_EPICS_AND_TASKS" --json
 # Returns: {"success": true, "id": "fn-N-epic-title", ...}
 ```
 

--- a/tests/scripts.test.ts
+++ b/tests/scripts.test.ts
@@ -16,6 +16,7 @@ const FLUX_ROOT = process.env.FLUX_ROOT ||
   join(import.meta.dir, '..')
 
 const SCRIPT_TIMEOUT = 15000
+const CREATE_APPROVAL_PHRASE = 'I_APPROVE_CREATING_EPICS_AND_TASKS'
 
 async function runScript(script: string, args: string[] = [], cwd?: string): Promise<string> {
   const scriptPath = join(FLUX_ROOT, 'scripts', script)
@@ -652,7 +653,10 @@ flowchart TD
 
     await $`${fluxctl} init --json`.cwd(tmpRoot).quiet()
     await $`${fluxctl} prime-mark --status done --json`.cwd(tmpRoot).quiet()
-    const epicRaw = await $`${fluxctl} epic create --title "Fix login redirect" --kind bug --scope-mode deep --technical-level non_technical --implementation-target engineer_handoff --json`.cwd(tmpRoot).text()
+    const epicRaw = await $`${fluxctl} epic create --title "Fix login redirect" --kind bug --scope-mode deep --technical-level non_technical --implementation-target engineer_handoff --json`
+      .env({ ...process.env, FLUX_CREATE_APPROVAL: CREATE_APPROVAL_PHRASE })
+      .cwd(tmpRoot)
+      .text()
     const epic = JSON.parse(epicRaw)
 
     await $`${fluxctl} epic set-workflow ${epic.id} --phase discover --step "repro-and-impact" --status in_progress --summary "Investigating repro path" --next-action "Confirm expected behavior" --open-question "Does this affect social login?" --activate --json`.cwd(tmpRoot).quiet()

--- a/tests/scripts.test.ts
+++ b/tests/scripts.test.ts
@@ -653,8 +653,7 @@ flowchart TD
 
     await $`${fluxctl} init --json`.cwd(tmpRoot).quiet()
     await $`${fluxctl} prime-mark --status done --json`.cwd(tmpRoot).quiet()
-    const epicRaw = await $`${fluxctl} epic create --title "Fix login redirect" --kind bug --scope-mode deep --technical-level non_technical --implementation-target engineer_handoff --json`
-      .env({ ...process.env, FLUX_CREATE_APPROVAL: CREATE_APPROVAL_PHRASE })
+    const epicRaw = await $`${fluxctl} epic create --title "Fix login redirect" --kind bug --scope-mode deep --technical-level non_technical --implementation-target engineer_handoff --approve ${CREATE_APPROVAL_PHRASE} --json`
       .cwd(tmpRoot)
       .text()
     const epic = JSON.parse(epicRaw)

--- a/tests/scripts.test.ts
+++ b/tests/scripts.test.ts
@@ -679,6 +679,26 @@ flowchart TD
     expect(session.router.node).toBe('Scope')
   }, SCRIPT_TIMEOUT)
 
+  test('epic create accepts upgrade objectives and preserves workflow metadata', async () => {
+    const tmpRoot = `/tmp/flux-upgrade-objective-${Date.now()}`
+    await $`mkdir -p ${tmpRoot}`.quiet()
+
+    await $`${fluxctl} init --json`.cwd(tmpRoot).quiet()
+    await $`${fluxctl} prime-mark --status done --json`.cwd(tmpRoot).quiet()
+
+    const epicRaw = await $`${fluxctl} epic create --title "Upgrade notifications with digest controls" --kind upgrade --scope-mode shallow --technical-level technical --implementation-target self_with_ai --approve ${CREATE_APPROVAL_PHRASE} --json`
+      .cwd(tmpRoot)
+      .text()
+    const epic = JSON.parse(epicRaw)
+
+    const statusRaw = await $`${fluxctl} scope-status --json`.cwd(tmpRoot).text()
+    const status = JSON.parse(statusRaw)
+    expect(status.objective.id).toBe(epic.id)
+    expect(status.objective.objective_kind).toBe('upgrade')
+    expect(status.objective.scope_mode).toBe('shallow')
+    expect(status.objective.technical_level).toBe('technical')
+  }, SCRIPT_TIMEOUT)
+
   test('agentmap --check reports built-in availability', async () => {
     const output = await $`${fluxctl} agentmap --check --json`
       .cwd(FLUX_ROOT)


### PR DESCRIPTION
## Summary

This PR makes Flux's planning flow explicit and gated.

It adds two protections:
- Flux must make the workflow entry choices explicit before planning continues.
- Flux must get explicit developer approval before creating any epic or task.

## Flow

### Before

```mermaid
flowchart LR
    A[New request] --> B[Infer intent]
    B --> C[Scope or plan]
    C --> D[Create epic/tasks]
```

### After

```mermaid
flowchart LR
    A[New request] --> B[Classify work: feature bug upgrade refactor]
    B --> C[Confirm audience: technical or non-technical]
    C --> D[Confirm depth: shallow or deep Double Diamond]
    D --> E[Confirm target: self with AI or engineer handoff]
    E --> F{Approved to create epics/tasks?}
    F -->|No| G[Stop and wait]
    F -->|Yes| H[Create epic/tasks]
```

## What Changed

### Explicit entry gates

Flux now has a clear START / preflight gate before scope or direct planning proceeds:
- classify the request as `feature`, `bug`, `upgrade`, or `refactor`
- confirm whether the user is `technical` or `non_technical`
- confirm whether `shallow` planning is enough or whether to use `deep` Double Diamond
- confirm whether the target is `self_with_ai` or `engineer_handoff`

If the user is non-technical, Flux should route to `propose` rather than continuing as a technical planning flow.

### Explicit approval gate

- `fluxctl epic create` and `fluxctl task create` now require `--approve "I_APPROVE_CREATING_EPICS_AND_TASKS"`
- the previous env-var authorization path was removed
- planning docs/skills now instruct Flux to stop and ask before any create call

### First-class `upgrade` support

`upgrade` is now a first-class objective kind in Flux metadata and related workflow/docs.

## Why

Before this PR:
- Flux could reach persistence too easily once planning converged.
- the start of the workflow relied too much on heuristics and implicit defaults.
- upgrades to existing features were not modeled as a first-class objective kind.

This PR makes the state machine more reliable and easier for the user to follow.

## Validation

- direct CLI checks:
  - create fails without approval
  - removed env-var path no longer authorizes creation
  - create succeeds with `--approve "I_APPROVE_CREATING_EPICS_AND_TASKS"`
- `bun test tests/scripts.test.ts --timeout 30000`
  - includes coverage for `upgrade` objectives

## Notes

- `bash scripts/ci_test.sh` still hits a pre-existing unrelated legacy harness failure later in the run (`extract_symbols_from_file` import issue). This PR does not introduce that.
